### PR TITLE
Fix reading tests on Linux

### DIFF
--- a/Sources/Pathos/readWrite.swift
+++ b/Sources/Pathos/readWrite.swift
@@ -29,17 +29,20 @@ public func readBytes(atPath path: String) throws -> [UInt8] {
     defer { close(fd) }
     var status = stat()
     fstat(fd, &status)
+    if _ifmt(status) == S_IFDIR {
+        return []
+    }
+
     let fileSize = Int(status.st_size)
-    var buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: fileSize + 1)
+    var buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: fileSize)
     defer { buffer.deallocate() }
     pread(fd, buffer.baseAddress!, fileSize, 0)
-    let end = buffer.endIndex.advanced(by: -1)
-    buffer[end] = 0
-    return [UInt8](buffer[..<end])
+    return [UInt8](buffer)
 }
 
 public func readString(atPath path: String) throws -> String {
     var content = try readBytes(atPath: path)
+    content.append(0)
     return String(cString: &content)
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -275,10 +275,14 @@ extension PathTests {
 }
 extension ReadingTests {
     static var allTests = [
+        ("testReadString", testReadString),
         ("testReadBytes", testReadBytes),
+        ("testReadStringFromDirectory", testReadStringFromDirectory),
         ("testReadStringFromNoWhere", testReadStringFromNoWhere),
         ("testReadSymbolicLink", testReadSymbolicLink),
+        ("testPathRepresentableReadString", testPathRepresentableReadString),
         ("testPathRepresentableReadBytes", testPathRepresentableReadBytes),
+        ("testPathRepresentableReadStringFromDirectory", testPathRepresentableReadStringFromDirectory),
         ("testPathRepresentableReadStringFromNoWhere", testPathRepresentableReadStringFromNoWhere),
         ("testPathRepresentableReadSymbolicLink", testPathRepresentableReadSymbolicLink),
     ]

--- a/Tests/PathosTests/ReadingTests.swift
+++ b/Tests/PathosTests/ReadingTests.swift
@@ -2,17 +2,17 @@ import Pathos
 import XCTest
 
 final class ReadingTests: FixtureTestCase {
-    // func testReadString() {
-    //     XCTAssertEqual(try readString(atPath: self.fixture(.fileThatExists)), "hello\n")
-    // }
+    func testReadString() {
+        XCTAssertEqual(try readString(atPath: self.fixture(.fileThatExists)), "hello\n")
+    }
 
     func testReadBytes() {
         XCTAssertEqual(try readBytes(atPath: self.fixture(.fileThatExists)), [UInt8]("hello\n".utf8))
     }
 
-    // func testReadStringFromDirectory() {
-    //     XCTAssertEqual(try readString(atPath: self.fixture(.directoryThatExists)), "")
-    // }
+    func testReadStringFromDirectory() {
+        XCTAssertEqual(try readString(atPath: self.fixture(.directoryThatExists)), "")
+    }
 
     func testReadStringFromNoWhere() {
         XCTAssertThrowsError(try readString(atPath: self.fixture(.noneExistence)))
@@ -22,17 +22,17 @@ final class ReadingTests: FixtureTestCase {
         XCTAssertEqual(try Pathos.readSymbolicLink(atPath: self.fixture(.goodFileSymbol)), "hello")
     }
 
-    // func testPathRepresentableReadString() {
-    //     XCTAssertEqual(self.fixturePath(.fileThatExists).readString(), "hello\n")
-    // }
+    func testPathRepresentableReadString() {
+        XCTAssertEqual(self.fixturePath(.fileThatExists).readString(), "hello\n")
+    }
 
     func testPathRepresentableReadBytes() {
         XCTAssertEqual(self.fixturePath(.fileThatExists).readBytes(), [UInt8]("hello\n".utf8))
     }
 
-    // func testPathRepresentableReadStringFromDirectory() {
-    //     XCTAssertEqual(self.fixturePath(.directoryThatExists).readString(), "")
-    // }
+    func testPathRepresentableReadStringFromDirectory() {
+        XCTAssertEqual(self.fixturePath(.directoryThatExists).readString(), "")
+    }
 
     func testPathRepresentableReadStringFromNoWhere() {
         XCTAssertEqual(self.fixturePath(.noneExistence).readString(), "")


### PR DESCRIPTION
Append `0` before converting from bytes to string. Hardcode empty content when
reading from directory.