### PR TITLE
Implement default temprary root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ export LC_CTYPE     = en_US.UTF-8
 test-all: test test-carthage
 
 update-linux-test-manifest:
+	@rm Tests/PathosTests/XCTestManifests.swift
 	@swift test --generate-linuxmain
 
 test: clean

--- a/Sources/Pathos/temporary.swift
+++ b/Sources/Pathos/temporary.swift
@@ -1,3 +1,73 @@
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+private func candidateTemporaryDirectories() -> [String] {
+    var list = [String]()
+    for envName in ["TMPDIR", "TEMP", "TMP"] {
+        if let cString = getenv(envName), let variable = String(validatingUTF8: cString) {
+            list.append(variable)
+        }
+    }
+
+    list.append(contentsOf: ["/tmp", "/var/tmp", "/usr/tmp"])
+    do {
+        list.append(try getCurrentWorkingDirectory())
+    } catch {
+    }
+
+    return list
+}
+
+/// Searches a standard list of directories to find one which the calling user can create files in.
+/// The list is:
+///
+/// - The directory named by the TMPDIR environment variable.
+/// - The directory named by the TEMP environment variable.
+/// - The directory named by the TMP environment variable.
+/// - The directories `/tmp`, `/var/tmp`, and `/usr/tmp`, in that order.
+/// - As a last resort, the current working directory.
+///
+/// - Returns: result of the search.
+public func searchForDefaultTemporaryDirectory() -> String {
+    for path in candidateTemporaryDirectories() where path != kCurrentDirectory {
+        do {
+            let p = try permissions(forPath: path)
+            if p.contains([.ownerRead, .ownerWrite]) {
+                return path
+            }
+        } catch {
+        }
+    }
+
+    return (try? makeAbsolute(path: kCurrentDirectory)) ?? kCurrentDirectory
+}
+
+private var _defaultTemporaryDirectory: String? = nil
+
+/// The name of the directory used for temporary files. This defines the default value for the `directory`
+/// argument to all functions involving a temporary path.
+///
+/// Pathos calls `searchForDefaultTemporaryDirectory` to calculate this value. The result of this search is
+/// cached. You can use the same method to reset this value if needed.
+public var defaultTemporaryDirectory: String {
+    get {
+        if let directory = _defaultTemporaryDirectory {
+            return directory
+        } else {
+            let directory = searchForDefaultTemporaryDirectory()
+            _defaultTemporaryDirectory = directory
+            return directory
+        }
+    }
+
+    set {
+        _defaultTemporaryDirectory = newValue
+    }
+}
+
 // TODO: Missing implementation.
 // TODO: Missing unit tests.
 // TODO: Missing docstring.
@@ -13,6 +83,35 @@ public func makeTemporaryDirectory(withSuffix suffix: String? = nil, prefix: Str
 }
 
 extension PathRepresentable {
+    /// The name of the directory used for temporary files. This defines the default value for the `directory`
+    /// argument to all functions involving a temporary path.
+    ///
+    /// Pathos calls `searchForDefaultTemporaryDirectory` to calculate this value. The result of this search is
+    /// cached. You can use the same method to reset this value if needed.
+    public static var defaultTemporaryDirectory: String {
+        get {
+            return Pathos.defaultTemporaryDirectory
+        }
+
+        set {
+            Pathos.defaultTemporaryDirectory = newValue
+        }
+    }
+
+    /// Searches a standard list of directories to find one which the calling user can create files in.
+    /// The list is:
+    ///
+    /// - The directory named by the TMPDIR environment variable.
+    /// - The directory named by the TEMP environment variable.
+    /// - The directory named by the TMP environment variable.
+    /// - The directories `/tmp`, `/var/tmp`, and `/usr/tmp`, in that order.
+    /// - As a last resort, the current working directory.
+    ///
+    /// - Returns: result of the search.
+    public static func searchForDefaultTemporaryDirectory() -> String {
+        return Pathos.searchForDefaultTemporaryDirectory()
+    }
+
     // TODO: Missing unit tests.
     // TODO: Missing docstring.
     public func makeTemporaryFile(withSuffix suffix: String? = nil, prefix: String? = nil, inDirectory directory: String? = nil) -> Self? {

--- a/Tests/PathosTests/DefaultTemporaryDirectorySearchingTests.swift
+++ b/Tests/PathosTests/DefaultTemporaryDirectorySearchingTests.swift
@@ -1,0 +1,91 @@
+import Pathos
+import XCTest
+
+private let kTMPDIR = "TMPDIR"
+private let kTEMP = "TEMP"
+private let kTMP = "TMP"
+
+private func generateTmp() -> String {
+    /// yup, these tests assumes `/tmp` exists and is read/writeable.
+    return join(path: "/tmp", withPath: String(UInt.random(in: .min ... .max)))
+}
+
+final class DefaultTemporaryDirectorySearchingTests: XCTestCase {
+    private var cachedTMPDIR: UnsafeMutablePointer<Int8>!
+    private var cachedTEMP: UnsafeMutablePointer<Int8>!
+    private var cachedTMP: UnsafeMutablePointer<Int8>!
+    private var tmp = generateTmp()
+
+    override func setUp() {
+        self.cachedTMPDIR = getenv(kTMPDIR)
+        self.cachedTEMP = getenv(kTEMP)
+        self.cachedTMP = getenv(kTMP)
+
+        mkdir(self.tmp, FilePermission.ownerAll.rawValue)
+    }
+
+    override func tearDown() {
+        if let cachedTMP = self.cachedTMP {
+            setenv(kTMP, cachedTMP, 1)
+        } else {
+            unsetenv(kTMP)
+        }
+
+        if let cachedTEMP = self.cachedTEMP {
+            setenv(kTEMP, cachedTEMP, 1)
+        } else {
+            unsetenv(kTEMP)
+        }
+
+        if let cachedTMPDIR = self.cachedTMPDIR {
+            setenv(kTMPDIR, cachedTMPDIR, 1)
+        } else {
+            unsetenv(kTMPDIR)
+        }
+
+        rmdir(self.tmp)
+        self.tmp = generateTmp()
+    }
+
+    func testSearchingTemporaryDirectoryFromTMPDIR() {
+        setenv(kTMPDIR, self.tmp, 1)
+        let searchResult = searchForDefaultTemporaryDirectory()
+        XCTAssertEqual(self.tmp, searchResult)
+    }
+
+    func testSearchingTemporaryDirectoryFromTEMP() {
+        unsetenv(kTMPDIR)
+        setenv(kTEMP, self.tmp, 1)
+        let searchResult = searchForDefaultTemporaryDirectory()
+        XCTAssertEqual(self.tmp, searchResult)
+    }
+
+    func testSearchingTemporaryDirectoryFromTMP() {
+        unsetenv(kTMPDIR)
+        unsetenv(kTEMP)
+        setenv(kTMP, self.tmp, 1)
+        let searchResult = searchForDefaultTemporaryDirectory()
+        XCTAssertEqual(self.tmp, searchResult)
+    }
+
+    func testPathRepresentableSearchingTemporaryDirectoryFromTMPDIR() {
+        setenv(kTMPDIR, self.tmp, 1)
+        let searchResult = Path.searchForDefaultTemporaryDirectory()
+        XCTAssertEqual(self.tmp, searchResult)
+    }
+
+    func testPathRepresentableSearchingTemporaryDirectoryFromTEMP() {
+        unsetenv(kTMPDIR)
+        setenv(kTEMP, self.tmp, 1)
+        let searchResult = Path.searchForDefaultTemporaryDirectory()
+        XCTAssertEqual(self.tmp, searchResult)
+    }
+
+    func testPathRepresentableSearchingTemporaryDirectoryFromTMP() {
+        unsetenv(kTMPDIR)
+        unsetenv(kTEMP)
+        setenv(kTMP, self.tmp, 1)
+        let searchResult = Path.searchForDefaultTemporaryDirectory()
+        XCTAssertEqual(self.tmp, searchResult)
+    }
+}

--- a/Tests/PathosTests/DefaultTemporaryDirectoryTests.swift
+++ b/Tests/PathosTests/DefaultTemporaryDirectoryTests.swift
@@ -1,0 +1,16 @@
+import Pathos
+import XCTest
+
+final class DefaultTemporaryDirectoryTests: XCTestCase {
+    func testDefaultsTemporaryDirectory() throws {
+        XCTAssertTrue(exists(atPath: defaultTemporaryDirectory))
+        let permissions = try Pathos.permissions(forPath: defaultTemporaryDirectory)
+        XCTAssertTrue(permissions.contains([.ownerRead, .ownerWrite]))
+    }
+
+    func testPathRepresentableDefaultsTemporaryDirectory() throws {
+        XCTAssertTrue(exists(atPath: Path.defaultTemporaryDirectory))
+        let permissions = try Pathos.permissions(forPath: Path.defaultTemporaryDirectory)
+        XCTAssertTrue(permissions.contains([.ownerRead, .ownerWrite]))
+    }
+}

--- a/Tests/PathosTests/XCTestManifests.swift
+++ b/Tests/PathosTests/XCTestManifests.swift
@@ -41,6 +41,24 @@ extension ChildrenTests {
     ]
 }
 
+extension DefaultTemporaryDirectorySearchingTests {
+    static let __allTests = [
+        ("testPathRepresentableSearchingTemporaryDirectoryFromTEMP", testPathRepresentableSearchingTemporaryDirectoryFromTEMP),
+        ("testPathRepresentableSearchingTemporaryDirectoryFromTMP", testPathRepresentableSearchingTemporaryDirectoryFromTMP),
+        ("testPathRepresentableSearchingTemporaryDirectoryFromTMPDIR", testPathRepresentableSearchingTemporaryDirectoryFromTMPDIR),
+        ("testSearchingTemporaryDirectoryFromTEMP", testSearchingTemporaryDirectoryFromTEMP),
+        ("testSearchingTemporaryDirectoryFromTMP", testSearchingTemporaryDirectoryFromTMP),
+        ("testSearchingTemporaryDirectoryFromTMPDIR", testSearchingTemporaryDirectoryFromTMPDIR),
+    ]
+}
+
+extension DefaultTemporaryDirectoryTests {
+    static let __allTests = [
+        ("testDefaultsTemporaryDirectory", testDefaultsTemporaryDirectory),
+        ("testPathRepresentableDefaultsTemporaryDirectory", testPathRepresentableDefaultsTemporaryDirectory),
+    ]
+}
+
 extension ExistsTests {
     static let __allTests = [
         ("testBadSymbolicLink", testBadSymbolicLink),
@@ -387,6 +405,8 @@ extension SplitPathTests {
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ChildrenTests.__allTests),
+        testCase(DefaultTemporaryDirectorySearchingTests.__allTests),
+        testCase(DefaultTemporaryDirectoryTests.__allTests),
         testCase(ExistsTests.__allTests),
         testCase(ExpandUserDirectoryTests.__allTests),
         testCase(FileExtensionTests.__allTests),


### PR DESCRIPTION
Copied behavior from Python with a different public interface design.
Instead of asking user to set the path to `nil` to reset to default
value, expose the function that calculate the default value so users can
use it to reset (or whatever).