### PR TITLE
Unify docstring format

### DIFF
--- a/Sources/Pathos/FilePermission.swift
+++ b/Sources/Pathos/FilePermission.swift
@@ -54,12 +54,12 @@ public struct FilePermission: OptionSet {
     /// This is the set-user-ID on execute bit.
     /// See [Process Persona](http://www.gnu.org/software/libc/manual/html_node/Process-Persona.html#Process-Persona)
     /// to learm more.
-    public static let setUserIDOnExecution     = FilePermission(rawValue: S_ISUID) /* set user id on execution */
+    public static let setUserIDOnExecution     = FilePermission(rawValue: S_ISUID)
 
     /// This is the set-group-ID on execute bit
     /// See [Process Persona](http://www.gnu.org/software/libc/manual/html_node/Process-Persona.html#Process-Persona)
     /// to learm more.
-    public static let setGroupIDOnExecution    = FilePermission(rawValue: S_ISGID) /* set group id on execution */
+    public static let setGroupIDOnExecution    = FilePermission(rawValue: S_ISGID)
 
     /// This is the sticky bit.
     ///
@@ -70,7 +70,7 @@ public struct FilePermission: OptionSet {
     /// the owner of the directory can delete any file in the directory, no matter who owns it (provided the
     /// owner has given himself write permission for the directory). This is commonly used for the /tmp
     /// directory, where anyone may create files but not delete files created by other users.
-    public static let saveSwappedTextAfterUser = FilePermission(rawValue: S_ISVTX) /* save swapped text even after use */
+    public static let saveSwappedTextAfterUser = FilePermission(rawValue: S_ISVTX)
 }
 
 extension FilePermission: ExpressibleByIntegerLiteral {

--- a/Sources/Pathos/PathRepresentable.swift
+++ b/Sources/Pathos/PathRepresentable.swift
@@ -4,6 +4,6 @@ public protocol PathRepresentable {
     var pathString: String { get }
     /// Initialize the type providing a string as path.
     ///
-    /// - Parameter string: string value for the path.
+    /// - parameter string: string value for the path.
     init(string: String)
 }

--- a/Sources/Pathos/PathosError.swift
+++ b/Sources/Pathos/PathosError.swift
@@ -2,10 +2,10 @@
 public enum PathosError: Error {
     /// Attempt to copy a path to a named pipe.
     ///
-    /// - Parameter path: the string value of the path.
+    /// - parameter path: the string value of the path.
     case attemptToCopyToNamedPipe(path: String)
     // Attempt to copy files but the path is neither a file nor a symbolic link to a file.
     ///
-    /// - Parameter path: the string value of the path.
+    /// - parameter path: the string value of the path.
     case copyingNeitherFileNorSymlink(path: String)
 }

--- a/Sources/Pathos/children.swift
+++ b/Sources/Pathos/children.swift
@@ -71,101 +71,109 @@ func _children<T>(_ path: T, recursive: Bool, block: (String, Bool) throws -> [S
 
 /// Find paths to directories and files of all types in `path`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - returns: path to directories and files of all types in `path`.
+/// - Returns: path to directories and files of all types in `path`.
 public func children(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, nil, recursive: recursive)
 }
 
-/// Find paths to files with unknown types in `path`.
+/// Find paths to files with unknown types in `path`. Known types are: pipes, character devices,
+/// directories, block devices, files, symbolic links and sockets.
 ///
-/// Known types are: pipes, character devices, directories, block devices, files, symbolic links and sockets.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
-///
-/// - returns: paths to files with unknown types in `path`.
+/// - Returns: paths to files with unknown types in `path`.
 public func unknownTypeFiles(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, Int32(DT_FIFO), recursive: recursive)
 }
 
 /// Find paths to pipes in `path`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - returns: path to all pipes in `path`.
+/// - Returns: path to all pipes in `path`.
 public func pipes(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, Int32(DT_UNKNOWN), recursive: recursive)
 }
 
 /// Find paths to character device files in `path`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - returns: path to all character device files in `path`.
+/// - Returns: path to all character device files in `path`.
 public func characterDevices(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, Int32(DT_CHR), recursive: recursive)
 }
 
 /// Find paths to directories in `path`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - returns: path to directories in `path`.
+/// - Returns: path to directories in `path`.
 public func directories(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, Int32(DT_DIR), recursive: recursive)
 }
 
 /// Find paths to block device files in `path`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - returns: path to block device files in `path`.
+/// - Returns: path to block device files in `path`.
 public func blockDevices(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, Int32(DT_BLK), recursive: recursive)
 }
 
 /// Find paths to normal files in `path`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - returns: path to normal files in `path`.
+/// - Returns: path to normal files in `path`.
 public func files(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, Int32(DT_REG), recursive: recursive)
 }
 
 /// Find paths to symbolic links (also known as symlinks or soft links) in `path`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - returns: path to symbolic links in `path`.
+/// - Returns: path to symbolic links in `path`.
 public func symbolicLinks(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, Int32(DT_LNK), recursive: recursive)
 }
 
 /// Find paths to sockets in `path`.
 ///
-/// - parameter path:      the path whose children will be returned.
-/// - parameter recursive: set to `true` to include results from child directories in addition to that
-///                        from `path`. Defaults to `false`.
+/// - Parameters:
+///   - path: the path whose children will be returned.
+///   - recursive: set to `true` to include results from child directories in addition to that from `path`.
+///                Defaults to `false`.
 ///
-/// - returns: path to sockets in `path`.
+/// - Returns: path to sockets in `path`.
 public func sockets(inPath path: String, recursive: Bool = false) throws -> [String] {
     return try _typedChildrenInPath(path, Int32(DT_SOCK), recursive: recursive)
 }
@@ -173,94 +181,91 @@ public func sockets(inPath path: String, recursive: Bool = false) throws -> [Str
 extension PathRepresentable {
     /// Find paths to child directories and files of all types.
     ///
-    /// - parameter path:      the path whose children will be returned.
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to directories and files of all types in `path`.
+    /// - Returns: paths to directories and files of all types in `path`.
     public func children(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: children(inPath:recursive:))
     }
 
-    /// Find paths to files with unknown types in `self`.
+    /// Find paths to files with unknown types in `self`. Known types are: pipes, character devices,
+    /// directories, block devices, files, symbolic links and sockets.
     ///
-    /// Known types are: pipes, character devices, directories, block devices, files, symbolic links and
-    /// sockets.
-    ///
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to files with unknown types in `self`.
+    /// - Returns: paths to files with unknown types in `self`.
     public func unknownTypeFiles(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: unknownTypeFiles(inPath:recursive:))
     }
 
     /// Find paths to pipes in `self`.
     ///
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to pipes in `self`.
+    /// - Returns: paths to pipes in `self`.
     public func pipes(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: pipes(inPath:recursive:))
     }
 
     /// Find paths to character devices in `self`.
     ///
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to character devices in `self`.
+    /// - Returns: paths to character devices in `self`.
     public func characterDevices(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: characterDevices(inPath:recursive:))
     }
 
     /// Find paths to directories in `self`.
     ///
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to character devices in `self`.
+    /// - Returns: paths to character devices in `self`.
     public func directories(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: directories(inPath:recursive:))
     }
 
     /// Find paths to block devices in `self`.
     ///
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to block devices in `self`.
+    /// - Returns: paths to block devices in `self`.
     public func blockDevices(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: blockDevices(inPath:recursive:))
     }
 
     /// Find paths to normal files in `self`.
     ///
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to normal files in `self`.
+    /// - Returns: paths to normal files in `self`.
     public func files(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: files(inPath:recursive:))
     }
 
     /// Find paths to symbolic links (also known as symlinks or soft links) in `self`.
     ///
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to symbolic links in `self`.
+    /// - Returns: paths to symbolic links in `self`.
     public func symbolicLinks(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: symbolicLinks(inPath:recursive:))
     }
 
     /// Find paths to sockets in `self`.
     ///
-    /// - parameter recursive: set to `true` to include results from child directories in addition to that
+    /// - Parameter recursive: set to `true` to include results from child directories in addition to that
     ///                        from `path`. Defaults to `false`.
     ///
-    /// - returns: paths to sockets in `self`.
+    /// - Returns: paths to sockets in `self`.
     public func sockets(recursive: Bool = false) -> [Self] {
         return _children(self, recursive: recursive, block: sockets(inPath:recursive:))
     }

--- a/Sources/Pathos/temporary.swift
+++ b/Sources/Pathos/temporary.swift
@@ -24,11 +24,11 @@ private func candidateTemporaryDirectories() -> [String] {
 /// Searches a standard list of directories to find one which the calling user can create files in.
 /// The list is:
 ///
-/// - The directory named by the TMPDIR environment variable.
-/// - The directory named by the TEMP environment variable.
-/// - The directory named by the TMP environment variable.
-/// - The directories `/tmp`, `/var/tmp`, and `/usr/tmp`, in that order.
-/// - As a last resort, the current working directory.
+/// * The directory named by the TMPDIR environment variable.
+/// * The directory named by the TEMP environment variable.
+/// * The directory named by the TMP environment variable.
+/// * The directories `/tmp`, `/var/tmp`, and `/usr/tmp`, in that order.
+/// * As a last resort, the current working directory.
 ///
 /// - Returns: result of the search.
 public func searchForDefaultTemporaryDirectory() -> String {


### PR DESCRIPTION
Use Xcode's default format because it's most contributor friendly.