### PR TITLE
Remove non-instance-specific methods

### DIFF
--- a/Sources/Pathos/currentWorkingDirectory.swift
+++ b/Sources/Pathos/currentWorkingDirectory.swift
@@ -33,17 +33,5 @@ extension PathRepresentable {
             try? setCurrentWorkingDirectory(to:)(newValue.pathString)
         }
     }
-
-    // TODO: missing unit tests.
-    // TODO: missing docstring.
-    public var currentWorkingDirectory: Self {
-        get {
-            return Self(string: (try? getCurrentWorkingDirectory()) ?? "")
-        }
-
-        set {
-            try? setCurrentWorkingDirectory(to:)(newValue.pathString)
-        }
-    }
 }
 

--- a/Sources/Pathos/glob.swift
+++ b/Sources/Pathos/glob.swift
@@ -11,10 +11,4 @@ extension PathRepresentable {
     public static func glob(_ pattern: String) -> [Self] {
         return Pathos.glob(_:)(pattern).map(Self.init)
     }
-
-    // TODO: Missing unit tests.
-    // TODO: Missing docstring.
-    public func glob(_ pattern: String) -> [Self] {
-        return Self.glob(_: self.join(with: Self(string: pattern)).pathString)
-    }
 }

--- a/Sources/Pathos/temporary.swift
+++ b/Sources/Pathos/temporary.swift
@@ -114,26 +114,6 @@ extension PathRepresentable {
 
     // TODO: Missing unit tests.
     // TODO: Missing docstring.
-    public func makeTemporaryFile(withSuffix suffix: String? = nil, prefix: String? = nil, inDirectory directory: String? = nil) -> Self? {
-        do {
-            return Self(string: try Pathos.makeTemporaryFile(withSuffix:prefix:inDirectory:)(suffix, prefix, directory))
-        } catch {
-            return nil
-        }
-    }
-
-    // TODO: Missing unit tests.
-    // TODO: Missing docstring.
-    public func makeTemporaryDirectory(withSuffix suffix: String? = nil, prefix: String? = nil, inDirectory directory: String? = nil) -> Self? {
-        do {
-            return Self(string: try Pathos.makeTemporaryDirectory(withSuffix:prefix:inDirectory:)(suffix, prefix, directory))
-        } catch {
-            return nil
-        }
-    }
-
-    // TODO: Missing unit tests.
-    // TODO: Missing docstring.
     public static func makeTemporaryFile(withSuffix suffix: String? = nil, prefix: String? = nil, inDirectory directory: String? = nil) -> Self? {
         do {
             return Self(string: try Pathos.makeTemporaryFile(withSuffix:prefix:inDirectory:)(suffix, prefix, directory))


### PR DESCRIPTION
These should stay static since they are not relavent to the specific
instance.