### PR TITLE
Fix children bug

### DIFF
--- a/Sources/Pathos/children.swift
+++ b/Sources/Pathos/children.swift
@@ -4,7 +4,7 @@ import Glibc
 import Darwin
 #endif
 
-func _typedChildrenInPath(_ path: String, _ type: Int32?, recursive: Bool = false) throws -> [String] {
+private func _typedChildrenInPath(_ path: String, _ type: Int32?, recursive: Bool = false) throws -> [String] {
     var result = [String]()
     let bufferPointer = UnsafeMutablePointer<UnsafeMutablePointer<UnsafeMutablePointer<dirent>?>?>.allocate(capacity: 0)
 #if os(Linux)
@@ -17,7 +17,7 @@ func _typedChildrenInPath(_ path: String, _ type: Int32?, recursive: Bool = fals
     let count = Int(scandir(path, bufferPointer, nil, alphasort))
 #endif
     if count == -1 {
-        throw SystemError.unknown(errorNumber: errno)
+        throw SystemError.init(posixErrorCode: errno)
     }
 
     result.reserveCapacity(count)
@@ -55,7 +55,7 @@ func _typedChildrenInPath(_ path: String, _ type: Int32?, recursive: Bool = fals
         }
 
         if recursive && pathType == DT_DIR {
-            result += try _typedChildrenInPath(join(path: path, withPaths: fullName), type, recursive: true)
+            result += try _typedChildrenInPath(fullName, type, recursive: true)
         }
     }
 
@@ -63,7 +63,7 @@ func _typedChildrenInPath(_ path: String, _ type: Int32?, recursive: Bool = fals
     return result
 }
 
-func _children<T>(_ path: T, recursive: Bool, block: (String, Bool) throws -> [String]) -> [T] where T: PathRepresentable {
+private func _children<T>(_ path: T, recursive: Bool, block: (String, Bool) throws -> [String]) -> [T] where T: PathRepresentable {
     let result = try? block(path.pathString, recursive)
         .map(T.init(string:))
     return result ?? []

--- a/Sources/Pathos/children.swift
+++ b/Sources/Pathos/children.swift
@@ -17,7 +17,7 @@ private func _typedChildrenInPath(_ path: String, _ type: Int32?, recursive: Boo
     let count = Int(scandir(path, bufferPointer, nil, alphasort))
 #endif
     if count == -1 {
-        throw SystemError.init(posixErrorCode: errno)
+        throw SystemError(posixErrorCode: errno)
     }
 
     result.reserveCapacity(count)

--- a/Tests/PathosTests/ChildrenTests.swift
+++ b/Tests/PathosTests/ChildrenTests.swift
@@ -2,6 +2,28 @@ import Pathos
 import XCTest
 
 final class ChildrenTests: XCTestCase {
+    var originalWorkingDirectory: String = (try? getCurrentWorkingDirectory()) ?? "."
+    override func setUp() {
+        _ = try? setCurrentWorkingDirectory(to: self.fixtureRoot)
+    }
+
+    override func tearDown() {
+        _ = try? setCurrentWorkingDirectory(to: self.originalWorkingDirectory)
+    }
+
+    func testRelativeDirectoryRecursive() throws {
+        // regression test!
+        XCTAssertEqual(
+            Set(try children(inPath: FixturePath.directoryThatExists.rawValue, recursive: true)),
+            Set([
+                FixturePath.fileInDirectory.rawValue,
+                FixturePath.symbolInDirectory.rawValue,
+                FixturePath.directoryInDirectory.rawValue,
+                FixturePath.fileInNestedDirectory.rawValue,
+            ])
+        )
+    }
+
     func testChildrenInPath() throws {
         XCTAssertEqual(
             Set(try children(inPath: self.fixtureRoot)),


### PR DESCRIPTION
When recursing into relative paths, child directory is joint with parent
twice. That leads to system error complaining about non-existing
directories. Fix this bug, add test for regression.