### PR TITLE
Implement relativePath

### DIFF
--- a/Sources/Pathos/constants.swift
+++ b/Sources/Pathos/constants.swift
@@ -4,7 +4,7 @@ import Glibc
 import Darwin
 #endif
 
-public let kCurrentDirectory = "."
+let kCurrentDirectory = "."
 let kParentDirectory = ".."
 let kSeparatorCharacter: Character = "/"
 let kSeparator = String(kSeparatorCharacter)

--- a/Sources/Pathos/helpers.swift
+++ b/Sources/Pathos/helpers.swift
@@ -23,3 +23,15 @@ extension BidirectionalCollection where Element: Equatable {
         return start
     }
 }
+
+extension Collection where Element: Equatable {
+    func commonPrefix(with other: Self) -> Self.SubSequence {
+        let limit = Swift.min(self.endIndex, other.endIndex)
+        var end = self.startIndex
+        while end < limit && self[end] == other[end] {
+            end = self.index(after: end)
+        }
+
+        return self[self.startIndex ..< end]
+    }
+}

--- a/Sources/Pathos/pathAnalysis.swift
+++ b/Sources/Pathos/pathAnalysis.swift
@@ -180,17 +180,27 @@ public func commonPath(amongPaths firstPath: String, _ secondPath: String, _ oth
     return _commonPath(amongPaths: [firstPath, secondPath] + otherPaths)
 }
 
-// TODO: Missing implementation.
-// TODO: Missing unit tests.
-/// Return a relative file path to `path` either from the current directory or from an optional starting
-/// directory. This is a path computation: the filesystem is not accessed to confirm the existence or
-/// nature of `path` or `startingPath`.
+/// Return relative location of `path` from from an another location.
+/// This is a pure computation: the filesystem is not accessed to confirm the existence or nature of `path` or
+/// `startingPath`.
+/// Example: starting from `/Users/dan`, the relative path of `/` would be `../..`.
+///
 /// - Parameters:
 ///   - path: the path the result is relative to.
 ///   - startingPath: starting path of the relativity.
 /// - Returns: a relative file path to `path`.
-public func relativePath(toPath path: String, startingFromPath startingPath: String = kCurrentDirectory) -> String {
-    fatalError("unimplemented")
+public func relativePath(ofPath path: String, startingFromPath startingPath: String) -> String {
+    let startSegments = startingPath.split(separator: kSeparatorCharacter)
+    let pathSegements = path.split(separator: kSeparatorCharacter)
+    let sharedCount = pathSegements.commonPrefix(with: startSegments).count
+    let parentSegments = Array(repeating: kParentDirectory, count: max(startSegments.count - sharedCount, 0))
+    let remainingSegments = pathSegements[sharedCount...].map(String.init)
+    let allSegments = parentSegments + remainingSegments
+    if allSegments.isEmpty {
+        return kCurrentDirectory
+    } else {
+        return allSegments.joined(separator: kSeparator)
+    }
 }
 
 extension PathRepresentable {
@@ -256,11 +266,15 @@ extension PathRepresentable {
         return commonString.isEmpty ? nil : Self(string: commonString)
     }
 
-    // TODO: Missing unit tests.
-    // TODO: Missing docstring.
-    // TODO: Missing default value for `startingPath`.
-    public func relative(to other: PathRepresentable, startingFrom startingPath: PathRepresentable) -> Self {
-        return Self(string: relativePath(toPath:startingFromPath:)(other.pathString, startingPath.pathString))
+    /// Return a relative path to `startingPath`.
+    /// This is a pure computation: the filesystem is not accessed to confirm the existence or nature of `path` or
+    /// `startingPath`.
+    /// Example: starting from `/Users/dan`, the relative path of `/` would be `../..`.
+    ///
+    /// - Parameter startingPath: starting path of the relativity.
+    /// - Returns: a relative file path to `path`.
+    public func relativePath(to startingPath: PathRepresentable) -> Self {
+        return Self(string: relativePath(ofPath:startingFromPath:)(self.pathString, startingPath.pathString))
     }
 }
 

--- a/Sources/Pathos/pathAnalysisWithIO.swift
+++ b/Sources/Pathos/pathAnalysisWithIO.swift
@@ -64,6 +64,17 @@ public func makeAbsolute(path: String) throws -> String {
     return normalize(path: path)
 }
 
+/// Return the relative location of `path` from the current working directory.
+/// Example: starting from `/Users/dan`, the relative path of `/` would be `../..`.
+/// - Parameter path: the path the result is relative to.
+/// - Returns: a relative file path to current working directory.
+/// - Throws: system error resulted from trying to access current working directory.
+public func relativePath(ofPath path: String) throws -> String {
+    let startingPath = try makeAbsolute(path: kCurrentDirectory)
+    let path = try makeAbsolute(path: path)
+    return relativePath(ofPath: path, startingFromPath: startingPath)
+}
+
 // TODO: Missing implementation.
 // TODO: Missing unit tests.
 /// Return the canonical path of the specified filename, eliminating any symbolic links encountered in the
@@ -83,6 +94,15 @@ extension PathRepresentable {
     // TODO: missing docstring.
     public func makeAbsolute() -> Self {
         return (try? makeAbsolute(path:)(self.pathString)).map(Self.init) ?? self
+    }
+
+    /// Return the relative location from the current working directory. The original value is returned if an
+    /// error was encountered while trying to access current working directory.
+    /// Example: starting from `/Users/dan`, the relative path of `/` would be `../..`.
+    /// - Returns: a relative file path to current working directory.
+    public func relativePath() -> Self {
+        let result = try? relativePath(ofPath:)(self.pathString)
+        return result.map(Self.init(string:)) ?? self
     }
 
     // TODO: Missing unit tests.

--- a/Tests/PathosTests/RelativePathInferringCurrentDirectoryTests.swift
+++ b/Tests/PathosTests/RelativePathInferringCurrentDirectoryTests.swift
@@ -1,0 +1,53 @@
+import Pathos
+import XCTest
+
+final class RelativePathInferringCurrentDirectoryTests: XCTestCase {
+    let originalWorkingDirectory = (try? Pathos.getCurrentWorkingDirectory()) ?? "."
+    var testRoot = makeTemporaryRoot()
+    /// create a new directory, which contains directories a/b/c. cd into a/b.
+    override func setUp() {
+        try! deletePath(self.testRoot)
+        let newRoot = makeTemporaryRoot()
+        try! makeDirectory(atPath: join(path: newRoot, withPath: "a/b/c"), createParents: true)
+        try! setCurrentWorkingDirectory(to: join(path: newRoot, withPath: "a/b"))
+        self.testRoot = try! normalize(path: join(path: getCurrentWorkingDirectory(), withPath: "../../"))
+    }
+
+    override func tearDown() {
+        _ = try? setCurrentWorkingDirectory(to: self.originalWorkingDirectory)
+    }
+
+    func testAbsoluteParent() throws {
+        XCTAssertEqual(try relativePath(ofPath: self.testRoot), "../..")
+    }
+
+    func testAbsoluteChild() throws {
+        let testPath = join(path: self.testRoot, withPath: "a/b/c")
+        XCTAssertEqual(try relativePath(ofPath: testPath), "c")
+    }
+
+    func testRelativeParent() throws {
+        XCTAssertEqual(try relativePath(ofPath: "../.."), "../..")
+    }
+
+    func testRelativeChild() throws {
+        XCTAssertEqual(try relativePath(ofPath: "./c"), "c")
+    }
+
+    func testPathRepresentableAbsoluteParent() throws {
+        XCTAssertEqual(Path(string: self.testRoot).relativePath().pathString, "../..")
+    }
+
+    func testPathRepresentableAbsoluteChild() throws {
+        let testPath = join(path: self.testRoot, withPath: "a/b/c")
+        XCTAssertEqual(Path(string: testPath).relativePath().pathString, "c")
+    }
+
+    func testPathRepresentableRelativeParent() throws {
+        XCTAssertEqual(Path(string: "../..").relativePath().pathString, "../..")
+    }
+
+    func testPathRepresentableRelativeChild() throws {
+        XCTAssertEqual(Path(string: "./c").relativePath().pathString, "c")
+    }
+}

--- a/Tests/PathosTests/RelativePathTests.swift
+++ b/Tests/PathosTests/RelativePathTests.swift
@@ -1,0 +1,54 @@
+import Pathos
+import XCTest
+
+final class RelativePathTests: XCTestCase {
+    func testRelativeSelf() {
+        XCTAssertEqual(relativePath(ofPath: "a", startingFromPath: "a"), ".")
+    }
+
+    func testRelativeParentSibling() {
+        XCTAssertEqual(relativePath(ofPath: "a", startingFromPath: "b/c"), "../../a")
+    }
+
+    func testAbsoluteSiblings() {
+        XCTAssertEqual(relativePath(ofPath: "/a/b", startingFromPath: "/x/y"), "../../a/b")
+    }
+
+    func testAbsoluteChild() {
+        XCTAssertEqual(relativePath(ofPath: "/a/b/c", startingFromPath: "/a/b"), "c")
+        XCTAssertEqual(relativePath(ofPath: "/a/b/c", startingFromPath: "/"), "a/b/c")
+    }
+
+    func testAbsoluteParent() {
+        XCTAssertEqual(relativePath(ofPath: "/", startingFromPath: "/a/b/c"), "../../..")
+    }
+
+    func testAbsoluteRoot() {
+        XCTAssertEqual(relativePath(ofPath: "/", startingFromPath: "/"), ".")
+    }
+
+    func testPathRepresentableRelativeSelf() {
+        XCTAssertEqual(Path(string: "a").relativePath(to: Path(string: "a")).pathString, ".")
+    }
+
+    func testPathRepresentableRelativeParentSibling() {
+        XCTAssertEqual(Path(string: "a").relativePath(to: Path(string: "b/c")).pathString, "../../a")
+    }
+
+    func testPathRepresentableAbsoluteSiblings() {
+        XCTAssertEqual(Path(string: "/a/b").relativePath(to: Path(string: "/x/y")).pathString, "../../a/b")
+    }
+
+    func testPathRepresentableAbsoluteChild() {
+        XCTAssertEqual(Path(string: "/a/b/c").relativePath(to: Path(string: "/a/b")).pathString, "c")
+        XCTAssertEqual(Path(string: "/a/b/c").relativePath(to: Path(string: "/")).pathString, "a/b/c")
+    }
+
+    func testPathRepresentableAbsoluteParent() {
+        XCTAssertEqual(Path(string: "/").relativePath(to: Path(string: "/a/b/c")).pathString, "../../..")
+    }
+
+    func testPathRepresentableAbsoluteRoot() {
+        XCTAssertEqual(Path(string: "/").relativePath(to: Path(string: "/")).pathString, ".")
+    }
+}

--- a/Tests/PathosTests/XCTestManifests.swift
+++ b/Tests/PathosTests/XCTestManifests.swift
@@ -376,6 +376,36 @@ extension ReadingTests {
     ]
 }
 
+extension RelativePathInferringCurrentDirectoryTests {
+    static let __allTests = [
+        ("testAbsoluteChild", testAbsoluteChild),
+        ("testAbsoluteParent", testAbsoluteParent),
+        ("testPathRepresentableAbsoluteChild", testPathRepresentableAbsoluteChild),
+        ("testPathRepresentableAbsoluteParent", testPathRepresentableAbsoluteParent),
+        ("testPathRepresentableRelativeChild", testPathRepresentableRelativeChild),
+        ("testPathRepresentableRelativeParent", testPathRepresentableRelativeParent),
+        ("testRelativeChild", testRelativeChild),
+        ("testRelativeParent", testRelativeParent),
+    ]
+}
+
+extension RelativePathTests {
+    static let __allTests = [
+        ("testAbsoluteChild", testAbsoluteChild),
+        ("testAbsoluteParent", testAbsoluteParent),
+        ("testAbsoluteRoot", testAbsoluteRoot),
+        ("testAbsoluteSiblings", testAbsoluteSiblings),
+        ("testPathRepresentableAbsoluteChild", testPathRepresentableAbsoluteChild),
+        ("testPathRepresentableAbsoluteParent", testPathRepresentableAbsoluteParent),
+        ("testPathRepresentableAbsoluteRoot", testPathRepresentableAbsoluteRoot),
+        ("testPathRepresentableAbsoluteSiblings", testPathRepresentableAbsoluteSiblings),
+        ("testPathRepresentableRelativeParentSibling", testPathRepresentableRelativeParentSibling),
+        ("testPathRepresentableRelativeSelf", testPathRepresentableRelativeSelf),
+        ("testRelativeParentSibling", testRelativeParentSibling),
+        ("testRelativeSelf", testRelativeSelf),
+    ]
+}
+
 extension SameFileTests {
     static let __allTests = [
         ("testNotSameFile", testNotSameFile),
@@ -478,6 +508,8 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(PathDirectoryTests.__allTests),
         testCase(PathTests.__allTests),
         testCase(ReadingTests.__allTests),
+        testCase(RelativePathInferringCurrentDirectoryTests.__allTests),
+        testCase(RelativePathTests.__allTests),
         testCase(SameFileTests.__allTests),
         testCase(SizeTests.__allTests),
         testCase(SplitExtensionTests.__allTests),


### PR DESCRIPTION
There are 2 variants:

Variant 1 is a pure computation that doesn't involve IO.
Variant 2 requires `getcwd` which could throw an error.

Implement, document, test.