### PR TITLE
Update path-joining interfaces

### DIFF
--- a/Sources/Pathos/children.swift
+++ b/Sources/Pathos/children.swift
@@ -49,7 +49,7 @@ private func _typedChildrenInPath(_ path: String, _ type: Int32?, recursive: Boo
         }
 #endif
 
-        let fullName = join(path: path, withPaths: name)
+        let fullName = join(paths: path, name)
         if type == nil || pathType == type {
             result.append(fullName)
         }

--- a/Sources/Pathos/pathAnalysis.swift
+++ b/Sources/Pathos/pathAnalysis.swift
@@ -32,10 +32,9 @@ public func isAbsolute(path: String) -> Bool {
     return path.hasPrefix(kSeparator)
 }
 
-// TODO: missing docstring.
-public func join(path: String, withPaths otherPaths: [String]) -> String {
-    var result = path
-    for other in otherPaths {
+public func join(paths: [String]) -> String {
+    var result = ""
+    for other in paths {
         if other.hasPrefix(kSeparator) {
             result = other
         } else if result.isEmpty || result.hasSuffix(kSeparator) {
@@ -49,18 +48,8 @@ public func join(path: String, withPaths otherPaths: [String]) -> String {
 }
 
 // TODO: missing docstring.
-public func join(path: String, withPath otherPath: String) -> String {
-    return join(path: path, withPaths: [otherPath])
-}
-
-// TODO: missing docstring.
-public func join(path: String, withPaths otherPaths: String...) -> String {
-    return join(path: path, withPaths: otherPaths)
-}
-
-// TODO: missing docstring.
-public func join(paths path: String, _ otherPaths: String...) -> String {
-    return join(path: path, withPaths: otherPaths)
+public func join(paths firstPath: String, _ secondPath: String, _ otherPaths: String...) -> String {
+    return join(paths: [firstPath, secondPath] + otherPaths)
 }
 
 // TODO: missing docstring.
@@ -215,14 +204,14 @@ extension PathRepresentable {
     }
 
     // TODO: missing docstring.
-    public func join(with otherPaths: [PathRepresentable]) -> Self {
-        let newPathString = join(path:withPaths:)(self.pathString, otherPaths.map { $0.pathString })
-        return Self(string: newPathString)
+    public func join(with paths: [PathRepresentable]) -> Self {
+        return Self(string: join(paths:)([self.pathString] + paths.map { $0.pathString }))
     }
 
     // TODO: missing docstring.
-    public func join(with otherPaths: PathRepresentable...) -> Self {
-        return self.join(with: otherPaths)
+    public func join(with secondPath: PathRepresentable, _ otherPaths: PathRepresentable...) -> Self {
+        let pathStrings = [self.pathString, secondPath.pathString] + otherPaths.map { $0.pathString }
+        return Self(string: join(paths:)(pathStrings))
     }
 
     // TODO: missing docstring.

--- a/Sources/Pathos/pathAnalysisWithIO.swift
+++ b/Sources/Pathos/pathAnalysisWithIO.swift
@@ -58,7 +58,7 @@ public func makeAbsolute(path: String) throws -> String {
             throw SystemError(posixErrorCode: errno)
         }
 
-        path = join(path: String(cString: buffer), withPaths: path)
+        path = join(paths: String(cString: buffer), path)
     }
 
     return normalize(path: path)

--- a/Sources/Pathos/temporary.swift
+++ b/Sources/Pathos/temporary.swift
@@ -72,7 +72,7 @@ func _makeTemporaryPath(suffix: String = "", prefix: String = "", inDirectory di
 {
     let location = directory ?? defaultTemporaryDirectory
     func makePath() -> String {
-        return join(path: location, withPath: prefix + String(Int64.random(in: .min ... .max)) + suffix)
+        return join(paths: location, prefix + String(Int64.random(in: .min ... .max)) + suffix)
     }
 
     var fileLocation = makePath()

--- a/Tests/PathosTests/DefaultTemporaryDirectorySearchingTests.swift
+++ b/Tests/PathosTests/DefaultTemporaryDirectorySearchingTests.swift
@@ -7,7 +7,7 @@ private let kTMP = "TMP"
 
 private func generateTmp() -> String {
     /// yup, these tests assumes `/tmp` exists and is read/writeable.
-    return join(path: "/tmp", withPath: String(UInt.random(in: .min ... .max)))
+    return join(paths: "/tmp", String(UInt.random(in: .min ... .max)))
 }
 
 final class DefaultTemporaryDirectorySearchingTests: XCTestCase {

--- a/Tests/PathosTests/FixtureSupport.swift
+++ b/Tests/PathosTests/FixtureSupport.swift
@@ -21,7 +21,7 @@ extension XCTestCase {
     }
 
     func fixture(_ path: FixturePath) -> String {
-        return join(path: self.fixtureRoot, withPath: path.rawValue)
+        return join(paths: self.fixtureRoot, path.rawValue)
     }
 
     func fixturePath(_ path: FixturePath) -> Path {

--- a/Tests/PathosTests/JoinPathTests.swift
+++ b/Tests/PathosTests/JoinPathTests.swift
@@ -2,39 +2,38 @@ import Pathos
 import XCTest
 
 final class JoinPathTests: XCTestCase {
-    func testSimpleSingleJoining() {
-        XCTAssertEqual(join(path: "/foo", withPath: "bar"), "/foo/bar")
-        XCTAssertEqual(join(path: "/foo", withPaths: "bar"), "/foo/bar")
-        XCTAssertEqual(join(path: "/foo", withPaths: ["bar"]), "/foo/bar")
+    func testJoiningNothing() {
+        XCTAssertEqual(join(paths: []), "")
+    }
+
+    func testSimpleSingleJoinings() {
+        XCTAssertEqual(join(paths: ["/foo", "bar"]), "/foo/bar")
         XCTAssertEqual(join(paths: "/foo", "bar"), "/foo/bar")
     }
 
     func testMultipleJoining() {
-        XCTAssertEqual(join(path: "/foo", withPaths: "bar", "baz"), "/foo/bar/baz")
-        XCTAssertEqual(join(path: "/foo", withPaths: ["bar", "baz"]), "/foo/bar/baz")
+        XCTAssertEqual(join(paths: ["/foo", "bar", "baz"]), "/foo/bar/baz")
         XCTAssertEqual(join(paths: "/foo", "bar", "baz"), "/foo/bar/baz")
     }
 
     func testMultipleJoiningWithTrailingSeparators() {
-        XCTAssertEqual(join(path: "/foo/", withPaths: "bar/", "baz/"), "/foo/bar/baz/")
-        XCTAssertEqual(join(path: "/foo/", withPaths: ["bar/", "baz/"]), "/foo/bar/baz/")
+        XCTAssertEqual(join(paths: ["/foo/", "bar/", "baz/"]), "/foo/bar/baz/")
         XCTAssertEqual(join(paths: "/foo/", "bar/", "baz/"), "/foo/bar/baz/")
     }
 
     func testJoiningWithAbsolutePath() {
-        XCTAssertEqual(join(path: "/foo", withPath: "/bar"), "/bar")
-        XCTAssertEqual(join(path: "/foo", withPaths: "/bar"), "/bar")
-        XCTAssertEqual(join(path: "/foo", withPaths: ["/bar"]), "/bar")
+        XCTAssertEqual(join(paths: ["/foo", "/bar"]), "/bar")
         XCTAssertEqual(join(paths: "/foo", "/bar"), "/bar")
-        XCTAssertEqual(join(path: "/foo", withPaths: "/bar", "baz"), "/bar/baz")
-        XCTAssertEqual(join(path: "/foo", withPaths: ["/bar", "baz"]), "/bar/baz")
+        XCTAssertEqual(join(paths: ["/foo", "/bar", "baz"]), "/bar/baz")
         XCTAssertEqual(join(paths: "/foo", "/bar", "baz"), "/bar/baz")
-        XCTAssertEqual(join(path: "/foo", withPaths: "bar", "/baz"), "/baz")
-        XCTAssertEqual(join(path: "/foo", withPaths: ["bar", "/baz"]), "/baz")
+        XCTAssertEqual(join(paths: ["/foo", "bar", "/baz"]), "/baz")
         XCTAssertEqual(join(paths: "/foo", "bar", "/baz"), "/baz")
     }
 
     func testPathRepresentableSimpleSingleJoining() {
+        XCTAssertEqual(
+            Path(string: "/foo").join(with: [Path(string: "bar")]).pathString,
+            "/foo/bar")
         XCTAssertEqual(
             Path(string: "/foo").join(with: Path(string: "bar")).pathString,
             "/foo/bar")
@@ -42,23 +41,46 @@ final class JoinPathTests: XCTestCase {
 
     func testPathRepresentableMultipleJoining() {
         XCTAssertEqual(
+            Path(string: "/foo").join(with: [Path(string: "bar"), Path(string: "baz")]).pathString,
+            "/foo/bar/baz")
+        XCTAssertEqual(
             Path(string: "/foo").join(with: Path(string: "bar"), Path(string: "baz")).pathString,
             "/foo/bar/baz")
     }
 
     func testPathRepresentableMultipleJoiningWithTrailingSeparators() {
         XCTAssertEqual(
+            Path(string: "/foo/").join(with: [Path(string: "bar/"), Path(string: "baz/")]).pathString,
+            "/foo/bar/baz/")
+        XCTAssertEqual(
             Path(string: "/foo/").join(with: Path(string: "bar/"), Path(string: "baz/")).pathString,
             "/foo/bar/baz/")
     }
 
+    func testPathRepresentableJoiningWithNothing() {
+        XCTAssertEqual(
+            Path(string: "/foo").join(with: []).pathString,
+            "/foo")
+    }
+
     func testPathRepresentableJoiningWithAbsolutePath() {
+        XCTAssertEqual(
+            Path(string: "/foo").join(with: [Path(string: "/bar")]).pathString,
+            "/bar")
         XCTAssertEqual(
             Path(string: "/foo").join(with: Path(string: "/bar")).pathString,
             "/bar")
+
+        XCTAssertEqual(
+            Path(string: "/foo").join(with: [Path(string: "/bar"), Path(string: "baz")]).pathString,
+            "/bar/baz")
         XCTAssertEqual(
             Path(string: "/foo").join(with: Path(string: "/bar"), Path(string: "baz")).pathString,
             "/bar/baz")
+
+        XCTAssertEqual(
+            Path(string: "/foo").join(with: [Path(string: "bar"), Path(string: "/baz")]).pathString,
+            "/baz")
         XCTAssertEqual(
             Path(string: "/foo").join(with: Path(string: "bar"), Path(string: "/baz")).pathString,
             "/baz")

--- a/Tests/PathosTests/MakeDirectoryTests.swift
+++ b/Tests/PathosTests/MakeDirectoryTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class MakeDirectoryTests: XCTestCase {
     private var randomTmpDirectoryPath: String {
-        return join(path: "/tmp", withPath: String(UInt64.random(in: .min ... .max)))
+        return join(paths: "/tmp", String(UInt64.random(in: .min ... .max)))
     }
 
     func testMakeDirectory() throws {
@@ -37,13 +37,13 @@ final class MakeDirectoryTests: XCTestCase {
     }
 
     func testMakeDirectoryWithNonExistParentShouldFail() {
-        let path = join(path: self.randomTmpDirectoryPath, withPath: "a/b/c")
+        let path = join(paths: self.randomTmpDirectoryPath, "a/b/c")
         XCTAssertThrowsError(try makeDirectory(atPath: path))
         XCTAssertFalse(exists(atPath: path))
     }
 
     func testMakeDirectoryWithCreateParent() throws {
-        let path = join(path: self.randomTmpDirectoryPath, withPath: "a/b/c")
+        let path = join(paths: self.randomTmpDirectoryPath, "a/b/c")
         try makeDirectory(atPath: path, createParents: true)
         XCTAssertTrue(try isDirectory(atPath: path))
         rmdir(path)
@@ -86,13 +86,13 @@ final class MakeDirectoryTests: XCTestCase {
     }
 
     func testPathRepresentableMakeDirectoryWithNonExistParentShouldFail() {
-        let path = join(path: self.randomTmpDirectoryPath, withPath: "a/b/c")
+        let path = join(paths: self.randomTmpDirectoryPath, "a/b/c")
         XCTAssertFalse(Path(string: path).makeDirectory())
         XCTAssertFalse(exists(atPath: path))
     }
 
     func testPathRepresentableMakeDirectoryWithCreateParent() {
-        let path = join(path: self.randomTmpDirectoryPath, withPath: "a/b/c")
+        let path = join(paths: self.randomTmpDirectoryPath, "a/b/c")
         XCTAssertTrue(Path(string: path).makeDirectory(createParents: true))
         XCTAssertTrue(try isDirectory(atPath: path))
         rmdir(path)

--- a/Tests/PathosTests/RelativePathInferringCurrentDirectoryTests.swift
+++ b/Tests/PathosTests/RelativePathInferringCurrentDirectoryTests.swift
@@ -8,9 +8,9 @@ final class RelativePathInferringCurrentDirectoryTests: XCTestCase {
     override func setUp() {
         try! deletePath(self.testRoot)
         let newRoot = makeTemporaryRoot()
-        try! makeDirectory(atPath: join(path: newRoot, withPath: "a/b/c"), createParents: true)
-        try! setCurrentWorkingDirectory(to: join(path: newRoot, withPath: "a/b"))
-        self.testRoot = try! normalize(path: join(path: getCurrentWorkingDirectory(), withPath: "../../"))
+        try! makeDirectory(atPath: join(paths: newRoot, "a/b/c"), createParents: true)
+        try! setCurrentWorkingDirectory(to: join(paths: newRoot, "a/b"))
+        self.testRoot = try! normalize(path: join(paths: getCurrentWorkingDirectory(), "../../"))
     }
 
     override func tearDown() {
@@ -22,7 +22,7 @@ final class RelativePathInferringCurrentDirectoryTests: XCTestCase {
     }
 
     func testAbsoluteChild() throws {
-        let testPath = join(path: self.testRoot, withPath: "a/b/c")
+        let testPath = join(paths: self.testRoot, "a/b/c")
         XCTAssertEqual(try relativePath(ofPath: testPath), "c")
     }
 
@@ -39,7 +39,7 @@ final class RelativePathInferringCurrentDirectoryTests: XCTestCase {
     }
 
     func testPathRepresentableAbsoluteChild() throws {
-        let testPath = join(path: self.testRoot, withPath: "a/b/c")
+        let testPath = join(paths: self.testRoot, "a/b/c")
         XCTAssertEqual(Path(string: testPath).relativePath().pathString, "c")
     }
 

--- a/Tests/PathosTests/XCTestManifests.swift
+++ b/Tests/PathosTests/XCTestManifests.swift
@@ -302,7 +302,7 @@ extension JoinPathTests {
         ("testPathRepresentableMultipleJoining", testPathRepresentableMultipleJoining),
         ("testPathRepresentableMultipleJoiningWithTrailingSeparators", testPathRepresentableMultipleJoiningWithTrailingSeparators),
         ("testPathRepresentableSimpleSingleJoining", testPathRepresentableSimpleSingleJoining),
-        ("testSimpleSingleJoining", testSimpleSingleJoining),
+        ("testSimpleSingleJoinings", testSimpleSingleJoinings),
     ]
 }
 


### PR DESCRIPTION
Clean up public interfaces so there are two versions left:

* a version that provides both type safety with signature guanrenteeing
at least 2 arguments are provided
* a version that takes an array of paths and tolerates zero arguments

And mirror these in PathRepresentable, of course.

Close #50