### PR TITLE
Add working directory execution

### DIFF
--- a/Sources/Pathos/currentWorkingDirectory.swift
+++ b/Sources/Pathos/currentWorkingDirectory.swift
@@ -31,6 +31,8 @@ public func setCurrentWorkingDirectory(toPath path: String) throws {
 /// Execute a closure with the current working direcotry being the specified path. Restore the current working
 /// directory when the execution is finished.
 ///
+/// The closure is guaranteed to be invoked synchronously.
+///
 /// - Parameters:
 ///   - path: The path that would be the current working directory.
 ///   - closure: The closure that will be called with `path` being the working directory.
@@ -63,6 +65,8 @@ extension PathRepresentable {
 
     /// Execute a closure with this path being the working directory. Restore the original working direcotry
     /// afterwards.
+    ///
+    /// The closure is guaranteed to be invoked synchronously.
     ///
     /// - Parameter closure: The closure to be called with this path being the working directory.
     public func asCurrentWorkingDirectory(performAction closure: @escaping () throws -> Void) {

--- a/Sources/Pathos/currentWorkingDirectory.swift
+++ b/Sources/Pathos/currentWorkingDirectory.swift
@@ -28,6 +28,22 @@ public func setCurrentWorkingDirectory(toPath path: String) throws {
     }
 }
 
+/// Execute a closure with the current working direcotry being the specified path. Restore the current working
+/// directory when the execution is finished.
+///
+/// - Parameters:
+///   - path: The path that would be the current working directory.
+///   - closure: The closure that will be called with `path` being the working directory.
+/// - Throws: Errors encountered setting or reading working directories.
+public func withWorkingDirectory(beingPath path: String, performAction closure: @escaping () throws -> Void) throws {
+    let originalDirectory = try getCurrentWorkingDirectory()
+    defer {
+        try? setCurrentWorkingDirectory(toPath: originalDirectory)
+    }
+    try setCurrentWorkingDirectory(toPath: path)
+    try closure()
+}
+
 extension PathRepresentable {
     /// The current working directory.
     ///
@@ -44,5 +60,12 @@ extension PathRepresentable {
             try? setCurrentWorkingDirectory(toPath:)(newValue.pathString)
         }
     }
-}
 
+    /// Execute a closure with this path being the working directory. Restore the original working direcotry
+    /// afterwards.
+    ///
+    /// - Parameter closure: The closure to be called with this path being the working directory.
+    public func asCurrentWorkingDirectory(performAction closure: @escaping () throws -> Void) {
+        try? withWorkingDirectory(beingPath: self.pathString, performAction: closure)
+    }
+}

--- a/Tests/PathosTests/CurrentWorkingDirectoryTests.swift
+++ b/Tests/PathosTests/CurrentWorkingDirectoryTests.swift
@@ -16,6 +16,19 @@ final class CurrentWorkingDirectoryTests: XCTestCase {
         try setCurrentWorkingDirectory(toPath: original)
     }
 
+    func testWorkingDirectoryBlock() throws {
+        let original = try getCurrentWorkingDirectory()
+        let temporary = try realPath(ofPath: makeTemporaryDirectory())
+        let expectation = self.expectation(description: "closure is executed")
+        try withWorkingDirectory(beingPath: temporary) {
+            expectation.fulfill()
+            XCTAssertEqual(try getCurrentWorkingDirectory(), temporary)
+        }
+
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 0.01), .completed)
+        XCTAssertEqual(try getCurrentWorkingDirectory(), original)
+    }
+
     func testPathRepresentableGetting() throws {
         XCTAssertFalse(Path.currentWorkingDirectory.pathString.isEmpty)
     }
@@ -29,5 +42,18 @@ final class CurrentWorkingDirectoryTests: XCTestCase {
         XCTAssertEqual(Path.currentWorkingDirectory.pathString, newDirectory.pathString)
 
         try setCurrentWorkingDirectory(toPath: original)
+    }
+
+    func testPathRepresentableWorkingDirectoryBlock() throws {
+        let original = Path.currentWorkingDirectory
+        let temporary = Path.makeTemporaryDirectory()!.realPath
+        let expectation = self.expectation(description: "closure is executed")
+        temporary.asCurrentWorkingDirectory {
+            expectation.fulfill()
+            XCTAssertEqual(try getCurrentWorkingDirectory(), temporary.pathString)
+        }
+
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 0.01), .completed)
+        XCTAssertEqual(try getCurrentWorkingDirectory(), original.pathString)
     }
 }

--- a/Tests/PathosTests/CurrentWorkingDirectoryTests.swift
+++ b/Tests/PathosTests/CurrentWorkingDirectoryTests.swift
@@ -19,13 +19,10 @@ final class CurrentWorkingDirectoryTests: XCTestCase {
     func testWorkingDirectoryBlock() throws {
         let original = try getCurrentWorkingDirectory()
         let temporary = try realPath(ofPath: makeTemporaryDirectory())
-        let expectation = self.expectation(description: "closure is executed")
         try withWorkingDirectory(beingPath: temporary) {
-            expectation.fulfill()
             XCTAssertEqual(try getCurrentWorkingDirectory(), temporary)
         }
 
-        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 0.01), .completed)
         XCTAssertEqual(try getCurrentWorkingDirectory(), original)
     }
 
@@ -47,13 +44,10 @@ final class CurrentWorkingDirectoryTests: XCTestCase {
     func testPathRepresentableWorkingDirectoryBlock() throws {
         let original = Path.currentWorkingDirectory
         let temporary = Path.makeTemporaryDirectory()!.realPath
-        let expectation = self.expectation(description: "closure is executed")
         temporary.asCurrentWorkingDirectory {
-            expectation.fulfill()
             XCTAssertEqual(try getCurrentWorkingDirectory(), temporary.pathString)
         }
 
-        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 0.01), .completed)
         XCTAssertEqual(try getCurrentWorkingDirectory(), original.pathString)
     }
 }

--- a/Tests/PathosTests/XCTestManifests.swift
+++ b/Tests/PathosTests/XCTestManifests.swift
@@ -87,7 +87,9 @@ extension CurrentWorkingDirectoryTests {
         ("testGetting", testGetting),
         ("testPathRepresentableGetting", testPathRepresentableGetting),
         ("testPathRepresentableSetting", testPathRepresentableSetting),
+        ("testPathRepresentableWorkingDirectoryBlock", testPathRepresentableWorkingDirectoryBlock),
         ("testSetting", testSetting),
+        ("testWorkingDirectoryBlock", testWorkingDirectoryBlock),
     ]
 }
 


### PR DESCRIPTION
Add APIs for executing block in a temporarily changed working directory. These proved to be super handy in practice.