### PR TITLE
Rename write API

### DIFF
--- a/Sources/Pathos/readWrite.swift
+++ b/Sources/Pathos/readWrite.swift
@@ -49,15 +49,13 @@ public func readString(atPath path: String) throws -> String {
 }
 
 // TODO: missing docstring.
-public func writeBytes<Bytes>(atPath path: String, _ bytes: Bytes, createIfNecessary: Bool = true, permission: FilePermission? = nil) throws where Bytes: Collection, Bytes.Element: BinaryInteger {
+public func write<Bytes>(_ bytes: Bytes, atPath path: String, createIfNecessary: Bool = true, permission: FilePermission? = nil) throws where Bytes: Collection, Bytes.Element: BinaryInteger {
     let buffer = bytes.map(UInt8.init(truncatingIfNeeded:))
     try _writeAtPath(path, bytes: buffer, byteCount: buffer.count, createIfNecessary: createIfNecessary, permission: permission)
 }
 
 // TODO: missing docstring.
-// TODO: `write(string:atPath...` might be better than `write(atPath:string...`
-//       or `writeString(_:atPath:)` matches with `readString(atPath:)`.
-public func writeString(atPath path: String, _ string: String, createIfNecessary: Bool = true, permission: FilePermission? = nil) throws {
+public func write(_ string: String, atPath path: String, createIfNecessary: Bool = true, permission: FilePermission? = nil) throws {
     try string.utf8CString.withUnsafeBytes { bytes in
         try _writeAtPath(path, bytes: bytes.baseAddress!, byteCount: bytes.count, createIfNecessary: createIfNecessary, permission: permission)
     }
@@ -75,11 +73,10 @@ extension PathRepresentable {
     }
 
     // TODO: missing docstring. Remember to note the byte truncating!
-    // TODO: `write(bytes:...`?
     @discardableResult
-    public func writeBytes<Bytes>(bytes: Bytes, createIfNecessary: Bool = true, permission: FilePermission? = nil) -> Bool where Bytes: Collection, Bytes.Element: BinaryInteger {
+    public func write<Bytes>(_ bytes: Bytes, createIfNecessary: Bool = true, permission: FilePermission? = nil) -> Bool where Bytes: Collection, Bytes.Element: BinaryInteger {
         do {
-            try writeBytes(atPath:_:createIfNecessary:permission:)(self.pathString, bytes, createIfNecessary, permission)
+            try write(_:atPath:createIfNecessary:permission:)(bytes, self.pathString, createIfNecessary, permission)
         } catch {
             return false
         }
@@ -87,11 +84,10 @@ extension PathRepresentable {
     }
 
     // TODO: missing docstring.
-    // TODO: `write(string:...`?
     @discardableResult
-    public func writeString(string: String, createIfNecessary: Bool = true, permission: FilePermission? = nil) -> Bool {
+    public func write(_ string: String, createIfNecessary: Bool = true, permission: FilePermission? = nil) -> Bool {
         do {
-            try writeString(atPath:_:createIfNecessary:permission:)(self.pathString, string, createIfNecessary, permission)
+            try write(_:atPath:createIfNecessary:permission:)(string, self.pathString, createIfNecessary, permission)
         } catch {
             return false
         }

--- a/Sources/Pathos/temporary.swift
+++ b/Sources/Pathos/temporary.swift
@@ -89,7 +89,7 @@ func _makeTemporaryPath(suffix: String = "", prefix: String = "", inDirectory di
 // TODO: Missing docstring.
 public func makeTemporaryFile(suffix: String = "", prefix: String = "", inDirectory directory: String? = nil) throws -> String {
     let fileLocation = try _makeTemporaryPath(suffix: suffix, prefix: prefix, inDirectory: directory)
-    try writeString(atPath: fileLocation, "")
+    try write("", atPath: fileLocation)
     return fileLocation
 }
 

--- a/Tests/PathosTests/MoveTests.swift
+++ b/Tests/PathosTests/MoveTests.swift
@@ -28,9 +28,9 @@ final class MoveTests: XCTestCase {
         try withTemporaryDirectory { _ in
             let filePath = "test"
             let fileContent = "hello"
-            try writeString(atPath: filePath, fileContent)
+            try write(fileContent, atPath: filePath)
             let otherFilePath = "test2"
-            try writeString(atPath: otherFilePath, fileContent + " world")
+            try write(fileContent + " world", atPath: otherFilePath)
 
             try movePath(filePath, toPath: otherFilePath)
 
@@ -56,7 +56,7 @@ final class MoveTests: XCTestCase {
     func testMixingTypes() throws {
         try withTemporaryDirectory { _ in
             let filePath = "test"
-            try writeString(atPath: filePath, "")
+            try write("", atPath: filePath)
             let directoryPath = "test2"
             try makeDirectory(atPath: directoryPath)
             XCTAssertThrowsError(try movePath(filePath, toPath: directoryPath))
@@ -89,9 +89,9 @@ final class MoveTests: XCTestCase {
         try withTemporaryDirectory { _ in
             let filePath = Path(string: "test")
             let fileContent = "hello"
-            filePath.writeString(string: fileContent)
+            filePath.write(fileContent)
             let otherFilePath = Path(string: "test2")
-            otherFilePath.writeString(string: fileContent + " world")
+            otherFilePath.write(fileContent + " world")
 
             XCTAssertTrue(filePath.move(to: otherFilePath))
 
@@ -117,7 +117,7 @@ final class MoveTests: XCTestCase {
     func testPathRepresentableMixingTypes() throws {
         try withTemporaryDirectory { _ in
             let filePath = Path(string: "test")
-            XCTAssertTrue(filePath.writeString(string: ""))
+            XCTAssertTrue(filePath.write(""))
             let directoryPath = Path(string: "test2")
             XCTAssertTrue(directoryPath.makeDirectory())
             XCTAssertFalse(filePath.move(to: directoryPath))

--- a/Tests/PathosTests/WritingTests.swift
+++ b/Tests/PathosTests/WritingTests.swift
@@ -19,7 +19,7 @@ final class WritingTests: XCTestCase {
         let expected = "Hello"
         let path = "world"
 
-        try writeString(atPath: path, expected)
+        try write(expected, atPath: path)
 
         let createdPermission = try permissions(forPath: path)
         XCTAssertEqual(createdPermission, self.defaultPermission)
@@ -29,9 +29,9 @@ final class WritingTests: XCTestCase {
     func testStringToExistingFile() throws {
         let expected = "Hello"
         let path = "world"
-        try writeString(atPath: path, "")
+        try write("", atPath: path)
 
-        try writeString(atPath: path, expected)
+        try write(expected, atPath: path)
 
         let createdPermission = try permissions(forPath: path)
         XCTAssertEqual(createdPermission, self.defaultPermission)
@@ -40,7 +40,7 @@ final class WritingTests: XCTestCase {
 
     func testStringToUnwantedNewFile() throws {
         let path = "world"
-        XCTAssertThrowsError(try writeString(atPath: path, "", createIfNecessary: false))
+        XCTAssertThrowsError(try write("", atPath: path, createIfNecessary: false))
     }
 
     func testBytesToNewFile() throws {
@@ -48,7 +48,7 @@ final class WritingTests: XCTestCase {
         let expectedBytes = expected.cString(using: String.defaultCStringEncoding)!
         let path = "world"
 
-        try writeBytes(atPath: path, expectedBytes)
+        try write(expectedBytes, atPath: path)
 
         let createdPermission = try permissions(forPath: path)
         XCTAssertEqual(createdPermission, self.defaultPermission)
@@ -60,9 +60,9 @@ final class WritingTests: XCTestCase {
         let expected = "Hello"
         let expectedBytes = expected.cString(using: String.defaultCStringEncoding)!
         let path = "world"
-        try writeString(atPath: path, "")
+        try write("", atPath: path)
 
-        try writeBytes(atPath: path, expectedBytes)
+        try write(expectedBytes, atPath: path)
 
         let createdPermission = try permissions(forPath: path)
         XCTAssertEqual(createdPermission, self.defaultPermission)
@@ -71,14 +71,14 @@ final class WritingTests: XCTestCase {
 
     func testBytesToUnwantedNewFile() throws {
         let path = "world"
-        XCTAssertThrowsError(try writeBytes(atPath: path, "".cString(using: .utf8)!, createIfNecessary: false))
+        XCTAssertThrowsError(try write("".cString(using: .utf8)!, atPath: path, createIfNecessary: false))
     }
 
     func testPathRepresentableStringToNewFile() throws {
         let expected = "Hello"
         let path = Path(string: "world")
 
-        XCTAssertTrue(path.writeString(string: expected))
+        XCTAssertTrue(path.write(expected))
 
         let createdPermission = try permissions(forPath: path.pathString)
         XCTAssertEqual(createdPermission, self.defaultPermission)
@@ -88,9 +88,9 @@ final class WritingTests: XCTestCase {
     func testPathRepresentableStringToExistingFile() throws {
         let expected = "Hello"
         let path = Path(string: "world")
-        try writeString(atPath: path.pathString, "")
+        try write(expected, atPath: path.pathString)
 
-        XCTAssertTrue(path.writeString(string: expected))
+        XCTAssertTrue(path.write(expected))
 
         let createdPermission = try permissions(forPath: path.pathString)
         XCTAssertEqual(createdPermission, self.defaultPermission)
@@ -99,7 +99,7 @@ final class WritingTests: XCTestCase {
 
     func testPathRepresentableStringToUnwantedNewFile() throws {
         let path = Path(string: "world")
-        XCTAssertFalse(path.writeString(string: "", createIfNecessary: false))
+        XCTAssertFalse(path.write("", createIfNecessary: false))
     }
 
     func testPathRepresentableBytesToNewFile() throws {
@@ -107,7 +107,7 @@ final class WritingTests: XCTestCase {
         let expectedBytes = expected.cString(using: String.defaultCStringEncoding)!
         let path = Path(string: "world")
 
-        XCTAssertTrue(path.writeBytes(bytes: expectedBytes))
+        XCTAssertTrue(path.write(expectedBytes))
 
         let createdPermission = try permissions(forPath: path.pathString)
         XCTAssertEqual(createdPermission, self.defaultPermission)
@@ -119,9 +119,9 @@ final class WritingTests: XCTestCase {
         let expected = "Hello"
         let expectedBytes = expected.cString(using: String.defaultCStringEncoding)!
         let path = Path(string: "world")
-        try writeString(atPath: path.pathString, "")
+        try write("", atPath: path.pathString)
 
-        XCTAssertTrue(path.writeBytes(bytes: expectedBytes))
+        XCTAssertTrue(path.write(expectedBytes))
 
         let createdPermission = try permissions(forPath: path.pathString)
         XCTAssertEqual(createdPermission, self.defaultPermission)
@@ -130,6 +130,6 @@ final class WritingTests: XCTestCase {
 
     func testPathRepresentableBytesToUnwantedNewFile() throws {
         let path = Path(string: "world")
-        XCTAssertFalse(path.writeBytes(bytes: "".cString(using: .utf8)!, createIfNecessary: false))
+        XCTAssertFalse(path.write("".cString(using: .utf8)!, createIfNecessary: false))
     }
 }


### PR DESCRIPTION
1. content comes first. Move away from the faux OOP mindset.
2. omit needless words. String, for example, **was** repeating the type
   information here.