### PR TITLE
Rename makeAbsolute to absolutePath

### DIFF
--- a/Sources/Pathos/pathAnalysisWithIO.swift
+++ b/Sources/Pathos/pathAnalysisWithIO.swift
@@ -51,8 +51,7 @@ public func expandUserDirectory(inPath path: String) throws -> String {
 }
 
 // TODO: missing docstring.
-// TODO: `makeAboslute` sounds like the path is being altered
-public func makeAbsolute(path: String) throws -> String {
+public func absolutePath(ofPath path: String) throws -> String {
     var path = path
     if !isAbsolute(path: path) {
         guard let buffer = getcwd(nil, 0) else {
@@ -71,8 +70,8 @@ public func makeAbsolute(path: String) throws -> String {
 /// - Returns: a relative file path to current working directory.
 /// - Throws: system error resulted from trying to access current working directory.
 public func relativePath(ofPath path: String) throws -> String {
-    let startingPath = try makeAbsolute(path: kCurrentDirectory)
-    let path = try makeAbsolute(path: path)
+    let startingPath = try absolutePath(ofPath: kCurrentDirectory)
+    let path = try absolutePath(ofPath: path)
     return relativePath(ofPath: path, startingFromPath: startingPath)
 }
 
@@ -147,7 +146,7 @@ public func realPath(ofPath path: String) throws -> String {
 
     var cache = [String: String]()
     let (result, _) = try _join("", path, seen: &cache)
-    return try makeAbsolute(path: result)
+    return try absolutePath(ofPath: result)
 }
 
 extension PathRepresentable {
@@ -157,8 +156,8 @@ extension PathRepresentable {
     }
 
     // TODO: missing docstring.
-    public func makeAbsolute() -> Self {
-        return (try? makeAbsolute(path:)(self.pathString)).map(Self.init) ?? self
+    public func absolutePath() -> Self {
+        return (try? absolutePath(ofPath:)(self.pathString)).map(Self.init) ?? self
     }
 
     /// Return the relative location from the current working directory. The original value is returned if an

--- a/Sources/Pathos/temporary.swift
+++ b/Sources/Pathos/temporary.swift
@@ -42,7 +42,7 @@ public func searchForDefaultTemporaryDirectory() -> String {
         }
     }
 
-    return (try? makeAbsolute(path: kCurrentDirectory)) ?? kCurrentDirectory
+    return (try? absolutePath(ofPath: kCurrentDirectory)) ?? kCurrentDirectory
 }
 
 private var _defaultTemporaryDirectory: String? = nil

--- a/Tests/PathosTests/MakeAbsoluteTests.swift
+++ b/Tests/PathosTests/MakeAbsoluteTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class MakeAbsoluteTests: XCTestCase {
     func testMakeAbsolutePath() {
         do {
-            let result = try makeAbsolute(path: "foo")
+            let result = try absolutePath(ofPath: "foo")
             XCTAssertTrue(result.hasPrefix("/"))
             XCTAssertTrue(result.hasSuffix("foo"))
         } catch let error {
@@ -13,7 +13,7 @@ final class MakeAbsoluteTests: XCTestCase {
     }
 
     func testPathRepresentableMakeAbsolutePath() {
-        let result = Path(string: "foo").makeAbsolute()
+        let result = Path(string: "foo").absolutePath()
         XCTAssertTrue(result.pathString.hasPrefix("/"))
         XCTAssertTrue(result.pathString.hasSuffix("foo"))
     }


### PR DESCRIPTION
This way it's less misleading. `make` suggests actual modification of
the file system.