### PR TITLE
Rename PathRepresentable.normalized

### DIFF
--- a/Sources/Pathos/pathAnalysis.swift
+++ b/Sources/Pathos/pathAnalysis.swift
@@ -1,5 +1,5 @@
 // TODO: missing docstring.
-/// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.normalize()`.
+/// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.normalized`.
 public func normalize(path: String) -> String {
     if path.isEmpty {
         return "."
@@ -207,7 +207,7 @@ public func relativePath(ofPath path: String, startingFromPath startingPath: Str
 extension PathRepresentable {
     // TODO: missing docstring.
     /// - SeeAlso: `normalize(path:)`.
-    public func normalize() -> Self {
+    public var normalized: Self {
         return Self(normalize(path:)(self.pathString))
     }
 

--- a/Tests/PathosTests/NormalizePathTests.swift
+++ b/Tests/PathosTests/NormalizePathTests.swift
@@ -19,18 +19,18 @@ final class NormalizePathTests: XCTestCase {
     }
 
     func testPathRepresentableEmptyPathBecomesCurrent() {
-        XCTAssertEqual(Path("").normalize().pathString, ".")
+        XCTAssertEqual(Path("").normalized.pathString, ".")
     }
 
     func testPathRepresentableSlashPrefixes() {
-        XCTAssertEqual(Path("/").normalize().pathString, "/")
-        XCTAssertEqual(Path("//").normalize().pathString, "//")
-        XCTAssertEqual(Path("///").normalize().pathString, "/")
+        XCTAssertEqual(Path("/").normalized.pathString, "/")
+        XCTAssertEqual(Path("//").normalized.pathString, "//")
+        XCTAssertEqual(Path("///").normalized.pathString, "/")
     }
 
     func testPathRepresentableCanonicalizePath() {
-        XCTAssertEqual(Path("///foo/.//bar//").normalize().pathString, "/foo/bar")
-        XCTAssertEqual(Path("///foo/.//bar//.//..//.//baz").normalize().pathString, "/foo/baz")
-        XCTAssertEqual(Path("///..//./foo/.//bar").normalize().pathString, "/foo/bar")
+        XCTAssertEqual(Path("///foo/.//bar//").normalized.pathString, "/foo/bar")
+        XCTAssertEqual(Path("///foo/.//bar//.//..//.//baz").normalized.pathString, "/foo/baz")
+        XCTAssertEqual(Path("///..//./foo/.//bar").normalized.pathString, "/foo/bar")
     }
 }


### PR DESCRIPTION
This is more aligned with the rest of the effect-free interfaces.