### PR TITLE
Add syntax sugar for joining paths

### DIFF
--- a/Sources/Pathos/pathAnalysis.swift
+++ b/Sources/Pathos/pathAnalysis.swift
@@ -290,3 +290,7 @@ extension PathRepresentable {
     }
 }
 
+/// Syntax sugar for joining two `PathRepresentable`s.
+public func + <T: PathRepresentable>(lhs: T, rhs: T) -> T {
+    return lhs.join(with: rhs)
+}

--- a/Tests/PathosTests/JoinPathTests.swift
+++ b/Tests/PathosTests/JoinPathTests.swift
@@ -37,6 +37,13 @@ final class JoinPathTests: XCTestCase {
         XCTAssertEqual(
             Path("/foo").join(with: Path("bar")).pathString,
             "/foo/bar")
+
+        XCTAssertEqual(
+            (Path("/foo") + Path("bar")).pathString,
+            "/foo/bar")
+        XCTAssertEqual(
+            (Path("/foo") + Path("bar")).pathString,
+            "/foo/bar")
     }
 
     func testPathRepresentableMultipleJoining() {


### PR DESCRIPTION
Use `+` for joining `PathRepresentable`s.