### PR TITLE
Use better Swift API for reading dirent field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
 ## master
 
-### Breaking
-
-- None
-
-### Enhancements
-
-- None
-
----
+- Removed a build warning in Swift 5.2


### PR DESCRIPTION
This removes a warning from Swift 5.2