### PR TITLE
Deprecate some permission APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ The following is added
 
 - `PathRepresentable.set(_:)` (permissions)
 
+Removed adding/removing permissions in favor of directly setting it.
+
+Deprecated the following:
+
+- `add(_:forPath:)`
+- `remove(_:forPath:)`
+- `PathRepresentable.add(_:)`
+- `PathRepresentable.remove(_:)`
+
 ## 0.2.3
 
 - Re-implemented `children(inPath:recursive)` to fix issue #122

--- a/Sources/Pathos/permissions.swift
+++ b/Sources/Pathos/permissions.swift
@@ -27,6 +27,7 @@ public func permissions(forPath path: String) throws -> FilePermission {
 ///   - path: The path whose permission is being changed.
 /// - Throws: System error encountered while attempting to read or change permissions at the path.
 /// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.add(_:)`.
+@available(*, deprecated, message: "use `set(_:forPath:)` instead")
 public func add(_ permissions: FilePermission, forPath path: String) throws {
     let existingPermission = try metadata(atPath: path).permissions
     try set(existingPermission.union(permissions), forPath: path)
@@ -40,6 +41,7 @@ public func add(_ permissions: FilePermission, forPath path: String) throws {
 ///   - path: The path whose permission is being changed.
 /// - Throws: System error encountered while attempting to read or change permissions at the path.
 /// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.remove(_:)`.
+@available(*, deprecated, message: "use `set(_:forPath:)` instead")
 public func remove(_ permissions: FilePermission, forPath path: String) throws {
     let existingPermission = try metadata(atPath: path).permissions
     try set(existingPermission.subtracting(permissions), forPath: path)
@@ -87,6 +89,7 @@ extension PathRepresentable {
     /// Set additional permissions to existing permission at this path. If this is an symbolic link, the
     /// permission for the link itself will be changed.
     /// - SeeAlso: `add(_:forPath:)`.
+    @available(*, deprecated, message: "use `self.set(_:)` instead")
     public func add(_ permissions: FilePermission) {
         try? add(_:forPath:)(permissions, self.pathString)
     }
@@ -94,6 +97,7 @@ extension PathRepresentable {
     /// Remove permissions from existing permission at a path. If this is an symbolic link, the
     /// permission for the link itself will be changed.
     /// - SeeAlso: `remove(_:forPath:)`.
+    @available(*, deprecated, message: "use `self.set(_:)` instead")
     public func remove(_ permissions: FilePermission) {
         try? remove(_:forPath:)(permissions, self.pathString)
     }

--- a/Tests/PathosTests/PermissionsTests.swift
+++ b/Tests/PathosTests/PermissionsTests.swift
@@ -19,30 +19,6 @@ final class PermissionsTests: XCTestCase {
         XCTAssertEqual(try metadata(atPath: destination).permissions, resultPermissions)
     }
 
-    func testAddingPermissions() throws {
-        let destination = try createTemporaryFile()
-        let initialPermissions: FilePermission = [.ownerRead, .ownerWrite, .otherRead, .groupRead]
-        XCTAssertEqual(try metadata(atPath: destination).permissions, initialPermissions)
-        let newPermission: FilePermission = .ownerExecute
-        let resultPermissions: FilePermission = initialPermissions.union(newPermission)
-
-        try Pathos.add(newPermission, forPath: destination)
-
-        XCTAssertEqual(try metadata(atPath: destination).permissions, resultPermissions)
-    }
-
-    func testRemovingPermissions() throws {
-        let destination = try createTemporaryFile()
-        let initialPermissions: FilePermission = [.ownerRead, .ownerWrite, .otherRead, .groupRead]
-        XCTAssertEqual(try metadata(atPath: destination).permissions, initialPermissions)
-        let permissionToRemove: FilePermission = .ownerExecute
-        let resultPermissions: FilePermission = initialPermissions.subtracting(permissionToRemove)
-
-        try Pathos.remove(permissionToRemove, forPath: destination)
-
-        XCTAssertEqual(try metadata(atPath: destination).permissions, resultPermissions)
-    }
-
     func testPathRepresentableReadingDefaultPermissions() {
         let destination = Path.createTemporaryFile()!
         let expectedPermissions: FilePermission = [.ownerRead, .ownerWrite, .otherRead, .groupRead]
@@ -56,30 +32,6 @@ final class PermissionsTests: XCTestCase {
         let resultPermissions: FilePermission = [.ownerRead, .ownerWrite]
 
         destination.set(resultPermissions)
-
-        XCTAssertEqual(destination.metadata()?.permissions, .some(resultPermissions))
-    }
-
-    func testPathRepresentableAddingPermissions() throws {
-        let destination = Path.createTemporaryFile()!
-        let initialPermissions: FilePermission = [.ownerRead, .ownerWrite, .otherRead, .groupRead]
-        XCTAssertEqual(try metadata(atPath: destination.pathString).permissions, initialPermissions)
-        let newPermission: FilePermission = .ownerExecute
-        let resultPermissions: FilePermission = initialPermissions.union(newPermission)
-
-        destination.add(newPermission)
-
-        XCTAssertEqual(destination.metadata()?.permissions, .some(resultPermissions))
-    }
-
-    func testPathRepresentableRemovingPermissions() throws {
-        let destination = Path.createTemporaryFile()!
-        let initialPermissions: FilePermission = [.ownerRead, .ownerWrite, .otherRead, .groupRead]
-        XCTAssertEqual(try metadata(atPath: destination.pathString).permissions, initialPermissions)
-        let permissionToRemove: FilePermission = .ownerExecute
-        let resultPermissions: FilePermission = initialPermissions.subtracting(permissionToRemove)
-
-        destination.remove(permissionToRemove)
 
         XCTAssertEqual(destination.metadata()?.permissions, .some(resultPermissions))
     }

--- a/Tests/PathosTests/XCTestManifests.swift
+++ b/Tests/PathosTests/XCTestManifests.swift
@@ -522,13 +522,9 @@ extension PermissionsTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__PermissionsTests = [
-        ("testAddingPermissions", testAddingPermissions),
-        ("testPathRepresentableAddingPermissions", testPathRepresentableAddingPermissions),
         ("testPathRepresentableReadingDefaultPermissions", testPathRepresentableReadingDefaultPermissions),
-        ("testPathRepresentableRemovingPermissions", testPathRepresentableRemovingPermissions),
         ("testPathRepresentableSettingPermissions", testPathRepresentableSettingPermissions),
         ("testReadingDefaultPermissions", testReadingDefaultPermissions),
-        ("testRemovingPermissions", testRemovingPermissions),
         ("testSettingPermissions", testSettingPermissions),
     ]
 }


### PR DESCRIPTION
Remove adding/removing permissions in favor of directly setting it.

Deprecated the following:

- `add(_:forPath:)`
- `remove(_:forPath:)`
- `PathRepresentable.add(_:)`
- `PathRepresentable.remove(_:)`