### PR TITLE
Improve consistency when refers to symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## master
 
+### New
 - Added a new type `Metadata`, which represents information from `stat` (Darwin,
   Linux).
 - Added API to retrieve `Metadata`.
+- `PathRepresentable.set(_:)` (permissions)
+
+
+### Deprecations
 
 The following APIs are deprecated in favor of metadata access APIs.
 
@@ -17,10 +22,6 @@ The following APIs are deprecated in favor of metadata access APIs.
 - `permissions(forPath:)`
 - `PathRepresentable.permissions`
 
-The following is added
-
-- `PathRepresentable.set(_:)` (permissions)
-
 Removed adding/removing permissions in favor of directly setting it.
 
 Deprecated the following:
@@ -29,6 +30,17 @@ Deprecated the following:
 - `remove(_:forPath:)`
 - `PathRepresentable.add(_:)`
 - `PathRepresentable.remove(_:)`
+
+### Breaking changes
+
+Previously symbolic links were referred to as "symbol" or "symbolic link" in
+APIs. From this version on, they'll be referred to as "symlink". This resulted
+in the following breaking changes
+
+- `exists(atPath:followSymbol:)` -> `exists(atPath:followSymlink:)`
+- `PathRepresentable.exists(followSymbol:)` -> `PathRepresentable.exists(followSymlink:)`
+- `copyFile(fromPath:toPath:followSymbolicLink:checkSize:)` -> `copyFile(fromPath:toPath:followSymlink:checkSize:)`
+- `PathRepresentable.copy(to:followSymbolicLink:checkSize:)` -> `PathRepresentable.copy(to:followSymlink:checkSize:)`
 
 ## 0.2.3
 

--- a/Sources/Pathos/attributes.swift
+++ b/Sources/Pathos/attributes.swift
@@ -8,12 +8,12 @@ import Darwin
 ///
 /// - Parameters:
 ///   - path: the path to be tested.
-///   - followSymbol: whether to follow symbolic links when retrieving the metadata.
+///   - followSymlink: whether to follow symbolic links when retrieving the metadata.
 /// - Throws: A `SystemError` if the file does not exist or is inaccessible.
 /// - Returns: metadata regarding file at the given path.
-/// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.metadata(followSymbol:)`.
-public func metadata(atPath path: String, followSymbol: Bool = true) throws -> Metadata {
-    return try Metadata(followSymbol ? _stat(at: path) : _lstat(at: path))
+/// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.metadata(followSymlink:)`.
+public func metadata(atPath path: String, followSymlink: Bool = true) throws -> Metadata {
+    return try Metadata(followSymlink ? _stat(at: path) : _lstat(at: path))
 }
 
 /// Whether file at path is of a type. Returns `false` if the path does not exist or is
@@ -35,12 +35,12 @@ public func isA(_ type: FileType, atPath path: String) throws -> Bool {
 ///
 /// - Parameters:
 ///   - path: the path to be tested.
-///   - followSymbol: whether to follow symbolic links. If `true`, return `false` for broken symbolic links.
+///   - followSymlink: whether to follow symbolic links. If `true`, return `false` for broken symbolic links.
 /// - Returns: whether path refers to an existing path or an open file descriptor.
-/// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.exists(followSymbol:)`.
-public func exists(atPath path: String, followSymbol: Bool = true) -> Bool {
+/// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.exists(followSymlink:)`.
+public func exists(atPath path: String, followSymlink: Bool = true) -> Bool {
     var status = stat()
-    return followSymbol ? stat(path, &status) == 0 : lstat(path, &status) == 0
+    return followSymlink ? stat(path, &status) == 0 : lstat(path, &status) == 0
 }
 
 /// Return the size in bytes of path.
@@ -49,7 +49,7 @@ public func exists(atPath path: String, followSymbol: Bool = true) -> Bool {
 /// - Returns: size of the file at path.
 /// - Throws: A `SystemError` if the file does not exist or is inaccessible.
 /// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.size`.
-@available(*, deprecated, message: "Use `metadata(atPath:followSymbol:).size` instead.")
+@available(*, deprecated, message: "Use `metadata(atPath:followSymlink:).size` instead.")
 public func size(atPath path: String) throws -> Int64 {
     return Int64(try _stat(at: path).st_size)
 }
@@ -60,7 +60,7 @@ public func size(atPath path: String) throws -> Int64 {
 /// - Returns: modification time in `FileTime`.
 /// - Throws: A `SystemError` if the file does not exist or is inaccessible.
 /// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.modificationTime`.
-@available(*, deprecated, message: "Use `metadata(atPath:followSymbol:).time.modified` instead.")
+@available(*, deprecated, message: "Use `metadata(atPath:followSymlink:).time.modified` instead.")
 public func modificationTime(atPath path: String) throws -> FileTime {
 #if os(Linux)
     return unsafeBitCast(try _stat(at: path).st_mtim, to: FileTime.self)
@@ -75,7 +75,7 @@ public func modificationTime(atPath path: String) throws -> FileTime {
 /// - Returns: time of last access in `FileTime`.
 /// - Throws: A `SystemError` if the file does not exist or is inaccessible.
 /// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.accessTime`.
-@available(*, deprecated, message: "Use `metadata(atPath:followSymbol:).time.accessed` instead.")
+@available(*, deprecated, message: "Use `metadata(atPath:followSymlink:).time.accessed` instead.")
 public func accessTime(atPath path: String) throws -> FileTime {
 #if os(Linux)
     return unsafeBitCast(try _stat(at: path).st_atim, to: FileTime.self)
@@ -90,7 +90,7 @@ public func accessTime(atPath path: String) throws -> FileTime {
 /// - Returns: time of last metadata change in `FileTime`.
 /// - Throws: A `SystemError` if the file does not exist or is inaccessible.
 /// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.metadataChangeTime`.
-@available(*, deprecated, message: "Use `metadata(atPath:followSymbol:).time.statusChanged` instead.")
+@available(*, deprecated, message: "Use `metadata(atPath:followSymlink:).time.statusChanged` instead.")
 public func metadataChangeTime(atPath path: String) throws -> FileTime {
 #if os(Linux)
     return unsafeBitCast(try _stat(at: path).st_ctim, to: FileTime.self)
@@ -124,18 +124,18 @@ extension PathRepresentable {
     /// broken symbolic links. On some platforms, this function may return `false` if permission is not
     /// granted to execute `stat` on the requested file, even if the path physically exists.
     ///
-    /// - Parameter followSymbol: whether to follow symbolic links. If `true`, return `false` for broken
+    /// - Parameter followSymlink: whether to follow symbolic links. If `true`, return `false` for broken
     ///                           symbolic links.
     /// - Returns: whether path refers to an existing path or an open file descriptor.
-    /// - SeeAlso: `exists(atPath:followSymbol:)`.
-    public func exists(followSymbol: Bool = true) -> Bool {
-        return exists(atPath:followSymbol:)(self.pathString, followSymbol)
+    /// - SeeAlso: `exists(atPath:followSymlink:)`.
+    public func exists(followSymlink: Bool = true) -> Bool {
+        return exists(atPath:followSymlink:)(self.pathString, followSymlink)
     }
 
     /// Return the size in bytes of path. Returns `false` if the path does not exist or is
     /// not accessible.
     /// - SeeAlso: `size(atPath:)`.
-    @available(*, deprecated, message: "use `self.metadata(followSymbol:).size` instead.")
+    @available(*, deprecated, message: "use `self.metadata(followSymlink:).size` instead.")
     public var size: Int64 {
         return (try? size(atPath:)(self.pathString)) ?? 0
     }
@@ -143,7 +143,7 @@ extension PathRepresentable {
     /// Return the time of last modification. Returns `nil` if the path does not exist or is
     /// not accessible.
     /// - SeeAlso: `modificationTime(atPath:)`.
-    @available(*, deprecated, message: "use `self.metadata(followSymbol:).time.modified` instead.")
+    @available(*, deprecated, message: "use `self.metadata(followSymlink:).time.modified` instead.")
     public var modificationTime: FileTime? {
         return try? modificationTime(atPath:)(self.pathString)
     }
@@ -151,7 +151,7 @@ extension PathRepresentable {
     /// Return the time of last access. Returns `nil` if the path does not exist or is
     /// not accessible.
     /// - SeeAlso: `accessTime(atPath:)`.
-    @available(*, deprecated, message: "use `self.metadata(followSymbol:).time.accessed` instead.")
+    @available(*, deprecated, message: "use `self.metadata(followSymlink:).time.accessed` instead.")
     public var accessTime: FileTime? {
         return try? accessTime(atPath:)(self.pathString)
     }
@@ -159,7 +159,7 @@ extension PathRepresentable {
     /// Return the system’s ctime which, on some systems (like Unix) is the time of the last metadata change,
     /// Returns `nil` if the path does not exist or is not accessible.
     /// - SeeAlso: `metadataChangeTime(atPath:)`.
-    @available(*, deprecated, message: "use `self.metadata(followSymbol:).time.statusChanged` instead.")
+    @available(*, deprecated, message: "use `self.metadata(followSymlink:).time.statusChanged` instead.")
     public var metadataChangeTime: FileTime? {
         return try? metadataChangeTime(atPath:)(self.pathString)
     }
@@ -176,12 +176,12 @@ extension PathRepresentable {
 
     /// Return metadata regarding the path.
     ///
-    /// - Parameter followSymbol: whether to follow symbolic links when retrieving the metadata.
+    /// - Parameter followSymlink: whether to follow symbolic links when retrieving the metadata.
     /// - Returns: metadata regarding file at the given path. `nil` if the file does not exist or is
     ///            inaccessible.
     /// - SeeAlso: To work with `Path` or `PathRepresentable`, use
-    ///            `PathRepresentable.metadata(followSymbol:)`.
-    public func metadata(followSymbol: Bool = true) -> Metadata? {
-        return try? metadata(atPath:followSymbol:)(self.pathString, followSymbol)
+    ///            `PathRepresentable.metadata(followSymlink:)`.
+    public func metadata(followSymlink: Bool = true) -> Metadata? {
+        return try? metadata(atPath:followSymlink:)(self.pathString, followSymlink)
     }
 }

--- a/Sources/Pathos/copy.swift
+++ b/Sources/Pathos/copy.swift
@@ -5,8 +5,8 @@ import Darwin
 #endif
 
 // TODO: missing docstring.
-/// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.copy(to:followSymbolicLink:chunkSize:)`.
-public func copyFile(fromPath source: String, toPath destination: String, followSymbolicLink: Bool = true, chunkSize: Int = 1024 * 16) throws {
+/// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.copy(to:followSymlink:chunkSize:)`.
+public func copyFile(fromPath source: String, toPath destination: String, followSymlink: Bool = true, chunkSize: Int = 1024 * 16) throws {
     var sourceStatus = try _lstat(at: source)
     let destinationStatus = try? _stat(at: destination)
     if _ifmt(sourceStatus) != S_IFREG && _ifmt(sourceStatus) != S_IFLNK {
@@ -24,7 +24,7 @@ public func copyFile(fromPath source: String, toPath destination: String, follow
     // some question from Python's standard library: What about other special files? (sockets, devices...)
 
     let isLink = _ifmt(sourceStatus) == S_IFLNK
-    if !followSymbolicLink && isLink {
+    if !followSymlink && isLink {
         try createSymbolicLink(fromPath: readSymbolicLink(atPath: source), toPath: destination)
         return
     }
@@ -64,11 +64,11 @@ public func copyFile(fromPath source: String, toPath destination: String, follow
 
 extension PathRepresentable {
     // TODO: missing docstring.
-    /// - SeeAlso: `copyFile(fromPath:toPath:followSymbolicLink:chunkSize:)`.
+    /// - SeeAlso: `copyFile(fromPath:toPath:followSymlink:chunkSize:)`.
     @discardableResult
-    public func copy(to destination: PathRepresentable, followSymbolicLink: Bool = true, chunkSize: Int = 1024 * 16) -> Bool {
+    public func copy(to destination: PathRepresentable, followSymlink: Bool = true, chunkSize: Int = 1024 * 16) -> Bool {
         do {
-            try copyFile(fromPath: self.pathString, toPath: destination.pathString, followSymbolicLink: followSymbolicLink, chunkSize: chunkSize)
+            try copyFile(fromPath: self.pathString, toPath: destination.pathString, followSymlink: followSymlink, chunkSize: chunkSize)
         } catch {
             return false
         }

--- a/Sources/Pathos/permissions.swift
+++ b/Sources/Pathos/permissions.swift
@@ -10,7 +10,7 @@ import Darwin
 /// - Parameter path: The path for which the permissions are get.
 /// - Throws: System error encountered while attempting to read permissions at the path.
 /// - SeeAlso: To work with `Path` or `PathRepresentable`, use `PathRepresentable.permissions`.
-@available(*, deprecated, message: "use `metadata(atPath:followSymbol:).permissions` instead")
+@available(*, deprecated, message: "use `metadata(atPath:followSymlink:).permissions` instead")
 public func permissions(forPath path: String) throws -> FilePermission {
     var status = stat()
     if lstat(path, &status) != 0 {
@@ -67,7 +67,7 @@ extension PathRepresentable {
     /// If an error is encountered while reading the permission, `FilePermission(rawValue: 0)` will be the
     /// value. If an error is encountered while setting the permission, this will be a no-op.
     /// - SeeAlso: `permissions(forPath:)`.
-    @available(*, deprecated, message: "use `metadata(atPath:followSymbol:).permissions` and self.set(_:) instead")
+    @available(*, deprecated, message: "use `metadata(atPath:followSymlink:).permissions` and self.set(_:) instead")
     public var permissions: FilePermission {
         get {
             return (try? permissions(forPath:)(self.pathString)) ?? FilePermission(rawValue: 0)

--- a/Tests/PathosTests/CopyFileTests.swift
+++ b/Tests/PathosTests/CopyFileTests.swift
@@ -38,11 +38,11 @@ final class CopyFileTests: XCTestCase {
     func testNotFollowingFileSymbol() throws {
         let destination = "hello"
         let source = self.fixture(.goodFileSymbol)
-        try copyFile(fromPath: source, toPath: destination, followSymbolicLink: false)
+        try copyFile(fromPath: source, toPath: destination, followSymlink: false)
         XCTAssertTrue(try isA(.symbolicLink, atPath: destination))
         try XCTAssertEqual(
-            metadata(atPath: destination, followSymbol: false).permissions,
-            metadata(atPath: source, followSymbol: false).permissions
+            metadata(atPath: destination, followSymlink: false).permissions,
+            metadata(atPath: source, followSymlink: false).permissions
         )
         XCTAssertEqual(try readSymbolicLink(atPath: destination), try readSymbolicLink(atPath: source))
     }
@@ -85,11 +85,11 @@ final class CopyFileTests: XCTestCase {
     func testPathRepresentableNotFollowingFileSymbol() {
         let destination = Path("hello")
         let source = self.fixturePath(.goodFileSymbol)
-        XCTAssertTrue(source.copy(to: destination, followSymbolicLink: false))
+        XCTAssertTrue(source.copy(to: destination, followSymlink: false))
         XCTAssertTrue(try isA(.symbolicLink, atPath: destination.pathString))
         try XCTAssertEqual(
-            metadata(atPath: destination.pathString, followSymbol: false).permissions,
-            metadata(atPath: source.pathString, followSymbol: false).permissions
+            metadata(atPath: destination.pathString, followSymlink: false).permissions,
+            metadata(atPath: source.pathString, followSymlink: false).permissions
         )
         XCTAssertEqual(
             try readSymbolicLink(atPath: destination.pathString),

--- a/Tests/PathosTests/ExistsTests.swift
+++ b/Tests/PathosTests/ExistsTests.swift
@@ -11,11 +11,11 @@ final class ExistsTests: XCTestCase {
     }
 
     func testExistingFilesFollowingSymbol() {
-        XCTAssertTrue(exists(atPath: self.fixture(.fileThatExists), followSymbol: true))
+        XCTAssertTrue(exists(atPath: self.fixture(.fileThatExists), followSymlink: true))
     }
 
     func testExistingFilesNotFollowingSymbol() {
-        XCTAssertTrue(exists(atPath: self.fixture(.fileThatExists), followSymbol: false))
+        XCTAssertTrue(exists(atPath: self.fixture(.fileThatExists), followSymlink: false))
     }
 
     func testGoodSymbolicLink() {
@@ -31,27 +31,27 @@ final class ExistsTests: XCTestCase {
     }
 
     func testGoodSymbolicLinkFollowingSymbol() {
-        XCTAssertTrue(exists(atPath: self.fixture(.goodFileSymbol), followSymbol: true))
+        XCTAssertTrue(exists(atPath: self.fixture(.goodFileSymbol), followSymlink: true))
     }
 
     func testGoodSymbolicDirectoryLinkFollowingSymbol() {
-        XCTAssertTrue(exists(atPath: self.fixture(.goodDirectorySymbol), followSymbol: true))
+        XCTAssertTrue(exists(atPath: self.fixture(.goodDirectorySymbol), followSymlink: true))
     }
 
     func testBadSymbolicLinkFollowingSymbol() {
-        XCTAssertFalse(exists(atPath: self.fixture(.badSymbol), followSymbol: true))
+        XCTAssertFalse(exists(atPath: self.fixture(.badSymbol), followSymlink: true))
     }
 
     func testGoodSymbolicLinkNotFollowingSymbol() {
-        XCTAssertTrue(exists(atPath: self.fixture(.goodFileSymbol), followSymbol: false))
+        XCTAssertTrue(exists(atPath: self.fixture(.goodFileSymbol), followSymlink: false))
     }
 
     func testGoodSymbolicDirectoryLinkNotFollowingSymbol() {
-        XCTAssertTrue(exists(atPath: self.fixture(.goodDirectorySymbol), followSymbol: false))
+        XCTAssertTrue(exists(atPath: self.fixture(.goodDirectorySymbol), followSymlink: false))
     }
 
     func testBadSymbolicLinkNotFollowingSymbol() {
-        XCTAssertTrue(exists(atPath: self.fixture(.badSymbol), followSymbol: false))
+        XCTAssertTrue(exists(atPath: self.fixture(.badSymbol), followSymlink: false))
     }
 
     func testPathRepresentableExistingFiles() {
@@ -63,11 +63,11 @@ final class ExistsTests: XCTestCase {
     }
 
     func testPathRepresentableExistingFileFollowingSymbol() {
-        XCTAssertTrue(self.fixturePath(.fileThatExists).exists(followSymbol: true))
+        XCTAssertTrue(self.fixturePath(.fileThatExists).exists(followSymlink: true))
     }
 
     func testPathRepresentableExistingFileNotFollowingSymbol() {
-        XCTAssertTrue(self.fixturePath(.fileThatExists).exists(followSymbol: false))
+        XCTAssertTrue(self.fixturePath(.fileThatExists).exists(followSymlink: false))
     }
 
     func testPathRepresentableGoodSymbolicLink() {
@@ -83,26 +83,26 @@ final class ExistsTests: XCTestCase {
     }
 
     func testPathRepresentableGoodSymbolicLinkFollowingSymbol() {
-        XCTAssertTrue(self.fixturePath(.goodFileSymbol).exists(followSymbol: true))
+        XCTAssertTrue(self.fixturePath(.goodFileSymbol).exists(followSymlink: true))
     }
 
     func testPathRepresentableGoodSymbolicDirectoryLinkFollowingSymbol() {
-        XCTAssertTrue(self.fixturePath(.goodDirectorySymbol).exists(followSymbol: true))
+        XCTAssertTrue(self.fixturePath(.goodDirectorySymbol).exists(followSymlink: true))
     }
 
     func testPathRepresentableBadSymbolicLinkFollowingSymbol() {
-        XCTAssertFalse(self.fixturePath(.badSymbol).exists(followSymbol: true))
+        XCTAssertFalse(self.fixturePath(.badSymbol).exists(followSymlink: true))
     }
 
     func testPathRepresentableGoodSymbolicLinkNotFollowingSymbol() {
-        XCTAssertTrue(self.fixturePath(.goodFileSymbol).exists(followSymbol: false))
+        XCTAssertTrue(self.fixturePath(.goodFileSymbol).exists(followSymlink: false))
     }
 
     func testPathRepresentableGoodDirectorySymbolicLinkNotFollowingSymbol() {
-        XCTAssertTrue(self.fixturePath(.goodDirectorySymbol).exists(followSymbol: false))
+        XCTAssertTrue(self.fixturePath(.goodDirectorySymbol).exists(followSymlink: false))
     }
 
     func testPathRepresentableBadSymbolicLinkNotFollowingSymbol() {
-        XCTAssertTrue(self.fixturePath(.badSymbol).exists(followSymbol: false))
+        XCTAssertTrue(self.fixturePath(.badSymbol).exists(followSymlink: false))
     }
 }


### PR DESCRIPTION
"symlink" should be a well understood term for users of this library.
Previous attemts to "English" the API is dubious at best.

However, due to the fact that these changes happens at arugment label
level, all of which came with default values, we can not properly
deprecate the old function names without introducing ambiguities at
user's callsite. So these will have to be breaking changes.

Closes #131