### PR TITLE
Fix cString pointer lifetime

### DIFF
--- a/Sources/Pathos/BinaryString.swift
+++ b/Sources/Pathos/BinaryString.swift
@@ -33,8 +33,10 @@ extension POSIXBinaryString {
         self = ContiguousArray(string.utf8CString.dropLast())
     }
 
-    public var cString: UnsafePointer<CChar> {
-        (self + [0]).withUnsafeBufferPointer { $0.baseAddress! }
+    public func cString<T>(action: (UnsafePointer<CChar>) throws -> T) throws -> T {
+        try (self + [0]).withUnsafeBufferPointer {
+            try action($0.baseAddress!)
+        }
     }
 
     public var description: String {
@@ -47,8 +49,10 @@ extension WindowsBinaryString {
         self = ContiguousArray(string.utf16)
     }
 
-    public var cString: UnsafePointer<UInt16> {
-        (self + [0]).withUnsafeBufferPointer { $0.baseAddress! }
+    public func cString<T>(action: (UnsafePointer<UInt16>) throws -> T) throws -> T {
+        try (self + [0]).withUnsafeBufferPointer {
+            try action($0.baseAddress!)
+        }
     }
 
     public var description: String {

--- a/Sources/Pathos/POSIX/Path+Darwin.swift
+++ b/Sources/Pathos/POSIX/Path+Darwin.swift
@@ -5,11 +5,13 @@ extension Path {
     public func metadata(followSymlink: Bool = false) throws -> Metadata {
         var status = stat()
         let correctStat = followSymlink ? stat : lstat
-        if correctStat(binaryString.cString, &status) != 0 {
-            throw SystemError(code: errno)
-        }
+        return try binaryString.cString { cString in
+            if correctStat(cString, &status) != 0 {
+                throw SystemError(code: errno)
+            }
 
-        return Metadata(status)
+            return Metadata(status)
+        }
     }
 }
 #endif // canImport(Darwin)

--- a/Sources/Pathos/POSIX/Path+Glibc.swift
+++ b/Sources/Pathos/POSIX/Path+Glibc.swift
@@ -4,25 +4,27 @@ import LinuxHelpers
 
 extension Path {
     public func metadata(followSymlink: Bool = false) throws -> Metadata {
-        let flags: UInt32 = UInt32(followSymlink ? 0 : AT_SYMLINK_NOFOLLOW)
-        var mode: UInt16 = 0
-        var size: UInt64 = 0
-        var atime = timespec()
-        var mtime = timespec()
-        var btime = timespec()
-        if linux_metadata(
-            binaryString.cString,
-            flags,
-            &mode,
-            &size,
-            &atime,
-            &mtime,
-            &btime
-        ) != 0 {
-            throw SystemError(code: errno)
-        }
+        try binaryString.cString { cString in
+            let flags: UInt32 = UInt32(followSymlink ? 0 : AT_SYMLINK_NOFOLLOW)
+            var mode: UInt16 = 0
+            var size: UInt64 = 0
+            var atime = timespec()
+            var mtime = timespec()
+            var btime = timespec()
+            if linux_metadata(
+                cString,
+                flags,
+                &mode,
+                &size,
+                &atime,
+                &mtime,
+                &btime
+            ) != 0 {
+                throw SystemError(code: errno)
+            }
 
-        return Metadata(mode: mode, size: size, atime: atime, mtime: mtime, btime: btime)
+            return Metadata(mode: mode, size: size, atime: atime, mtime: mtime, btime: btime)
+        }
     }
 }
 #endif // canImport(Glibc)


### PR DESCRIPTION
`BinaryString.cString` previously returns an unscoped pointer to its storage, which is against recommendation of Swift's documentation. Fix it by exposing the pointer to a scope.