### PR TITLE
Fix recursive children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+- Fix a bug where `children` always recusively visit its content when following symlinks.
+
 ## 0.3.1
 
 - children() can follow symlinks found in the content if `followSymlink`

--- a/Sources/Pathos/children.swift
+++ b/Sources/Pathos/children.swift
@@ -48,7 +48,7 @@ public func children(inPath path: String, recursive: Bool = false, followSymlink
            let realName = try? realPath(ofPath: fullName),
            (try? isA(.directory, atPath: realName)) == true
         {
-            result += try children(inPath: fullName, recursive: true)
+            result += try children(inPath: fullName, recursive: recursive)
         } else if recursive && pathType == .directory {
             result += try children(inPath: fullName, recursive: true)
         }


### PR DESCRIPTION
Following symlink shouldn't imply recursive