### PR TITLE
Add `utf8` to Path.write

### DIFF
--- a/Sources/Pathos/Path.swift
+++ b/Sources/Pathos/Path.swift
@@ -155,7 +155,7 @@ public struct Path {
     }
 
     public func write(
-        _ string: String,
+        utf8 string: String,
         createIfNecessary: Bool = true,
         truncate: Bool = true
     ) throws {

--- a/Tests/PathosTests/ChildrenTests.swift
+++ b/Tests/PathosTests/ChildrenTests.swift
@@ -4,9 +4,9 @@ import XCTest
 final class ChildrenTests: XCTestCase {
     func testListingChildrenNonRecursively() throws {
         try Path.withTemporaryDirectory { container in
-            try Path("a").write("")
+            try Path("a").write(utf8: "")
             try Path("b").makeDirectory()
-            try (Path("b") + "c").write("")
+            try (Path("b") + "c").write(utf8: "")
             try Path("a").makeSymlink(at: Path("d"))
             var children = try container.children()
                 .map { ($0.name ?? "", $1.isDirectory, $1.isSymlink, $1.isFile) }
@@ -29,9 +29,9 @@ final class ChildrenTests: XCTestCase {
 
     func testListingChildrenRecursively() throws {
         try Path.withTemporaryDirectory { _ in
-            try Path("a").write("")
+            try Path("a").write(utf8: "")
             try Path("b").makeDirectory()
-            try (Path("b") + "c").write("")
+            try (Path("b") + "c").write(utf8: "")
             try Path("a").makeSymlink(at: Path("d"))
             var children = try Path(".").children(recursive: true)
                 .map { ($0.name ?? "", $1.isDirectory, $1.isSymlink, $1.isFile) }
@@ -58,11 +58,11 @@ final class ChildrenTests: XCTestCase {
 
     func testListingChildrenRecursivelyFollowingSymlink() throws {
         try Path.withTemporaryDirectory { _ in
-            try Path("a").write("")
+            try Path("a").write(utf8: "")
             try Path("b").makeDirectory()
             try (Path("b") + "e").makeDirectory()
-            try (Path("b") + "e" + "f").write("")
-            try (Path("b") + "c").write("")
+            try (Path("b") + "e" + "f").write(utf8: "")
+            try (Path("b") + "c").write(utf8: "")
             try Path("b").makeSymlink(at: Path("d"))
             let children = try Path(".").children(recursive: true, followSymlink: true)
             let names = Set(children.map(\.0))

--- a/Tests/PathosTests/CopyTests.swift
+++ b/Tests/PathosTests/CopyTests.swift
@@ -6,7 +6,7 @@ final class CopyTests: XCTestCase {
         try Path.withTemporaryDirectory { _ in
             let content = "xyyyzz"
             let sourceFile = Path("a")
-            try sourceFile.write(content)
+            try sourceFile.write(utf8: content)
             let destinationFile = Path("b")
             try sourceFile.copy(to: destinationFile)
             XCTAssertEqual(try destinationFile.readUTF8String(), content)
@@ -17,7 +17,7 @@ final class CopyTests: XCTestCase {
         try Path.withTemporaryDirectory { _ in
             let content = "aoesubaoesurcaoheu"
             let sourceFile = Path("a")
-            try sourceFile.write(content)
+            try sourceFile.write(utf8: content)
             let link = Path("b")
             try sourceFile.makeSymlink(at: link)
             let destinationFile = Path("c")
@@ -30,7 +30,7 @@ final class CopyTests: XCTestCase {
         try Path.withTemporaryDirectory { _ in
             let content = "aoesubaoesurcaoheu"
             let sourceFile = Path("a")
-            try sourceFile.write(content)
+            try sourceFile.write(utf8: content)
             let link = Path("b")
             try sourceFile.makeSymlink(at: link)
             let destinationFile = Path("c")
@@ -45,8 +45,8 @@ final class CopyTests: XCTestCase {
             let sourceFile = Path("a")
             let destinationFile = Path("b")
 
-            try sourceFile.write(sourceContent)
-            try destinationFile.write("bbb")
+            try sourceFile.write(utf8: sourceContent)
+            try destinationFile.write(utf8: "bbb")
 
             try sourceFile.copy(to: destinationFile)
             XCTAssertEqual(try destinationFile.readUTF8String(), sourceContent)

--- a/Tests/PathosTests/GlobTests.swift
+++ b/Tests/PathosTests/GlobTests.swift
@@ -7,9 +7,9 @@ final class GlobTests: XCTestCase {
             let path0 = Path("1.swift")
             let path1 = Path("b.swift")
             let path2 = Path("3.py")
-            try path0.write("")
-            try path1.write("")
-            try path2.write("")
+            try path0.write(utf8: "")
+            try path1.write(utf8: "")
+            try path2.write(utf8: "")
 
             XCTAssertEqual(
                 Set(try Path("*.swift").glob()),
@@ -44,7 +44,7 @@ final class GlobTests: XCTestCase {
             }
 
             for file in files {
-                try file.write("")
+                try file.write(utf8: "")
             }
 
             XCTAssertEqual(

--- a/Tests/PathosTests/MetadataTests.swift
+++ b/Tests/PathosTests/MetadataTests.swift
@@ -12,7 +12,7 @@ final class MetadataTests: XCTestCase {
     func testRetrievingFileMetadata() throws {
         try Path.withTemporaryDirectory { _ in
             let path = Path("a")
-            try path.write("")
+            try path.write(utf8: "")
             let meta = try path.metadata()
             XCTAssertTrue(meta.fileType.isFile)
         }
@@ -21,7 +21,7 @@ final class MetadataTests: XCTestCase {
     func testRetrievingSymlinkMetadata() throws {
         try Path.withTemporaryDirectory { _ in
             let path = Path("a")
-            try path.write("")
+            try path.write(utf8: "")
             let link = Path("b")
             try path.makeSymlink(at: link)
             let meta = try link.metadata()

--- a/Tests/PathosTests/RealTests.swift
+++ b/Tests/PathosTests/RealTests.swift
@@ -5,7 +5,7 @@ final class RealTests: XCTestCase {
     func testResolvingSimpleSymlink() throws {
         try Path.withTemporaryDirectory { _ in
             let origin = Path("a")
-            try origin.write("")
+            try origin.write(utf8: "")
             let link = Path("b")
             try origin.makeSymlink(at: link)
             let real = try link.real()
@@ -17,7 +17,7 @@ final class RealTests: XCTestCase {
     func testResolving2LevelSymlink() throws {
         try Path.withTemporaryDirectory { _ in
             let origin = Path("a")
-            try origin.write("")
+            try origin.write(utf8: "")
             let link1 = Path("b")
             let link2 = Path("c")
             try origin.makeSymlink(at: link1)
@@ -32,7 +32,7 @@ final class RealTests: XCTestCase {
         try Path.withTemporaryDirectory { _ in
             let dir = Path("dir")
             try dir.makeDirectory()
-            try (dir + "a").write("")
+            try (dir + "a").write(utf8: "")
             let dirLink = Path("dirlink")
             try dir.makeSymlink(at: dirLink)
             let file = dirLink + "a"

--- a/Tests/PathosTests/SymlinkTests.swift
+++ b/Tests/PathosTests/SymlinkTests.swift
@@ -5,7 +5,7 @@ final class SymlinkTests: XCTestCase {
     func testMakingAndReadingSymlinks() throws {
         try Path.withTemporaryDirectory { _ in
             let source = Path("a")
-            try source.write("a")
+            try source.write(utf8: "a")
             let link = Path("b")
             try source.makeSymlink(at: link)
             XCTAssertEqual(try link.readSymlink(), source)

--- a/Tests/PathosTests/WriteTests.swift
+++ b/Tests/PathosTests/WriteTests.swift
@@ -25,7 +25,7 @@ final class WriteTests: XCTestCase {
     func testWritingString() throws {
         try Path.withTemporaryDirectory { _ in
             let path = Path("a.txt")
-            try path.write("axx", createIfNecessary: true)
+            try path.write(utf8: "axx", createIfNecessary: true)
             XCTAssert(path.exists())
             XCTAssertEqual(try path.readBytes(), [97, 120, 120])
         }


### PR DESCRIPTION
Make it explicit what we are writing.

Closes #263.