### PR TITLE
Resolve ambiguity

### DIFF
--- a/Sources/Pathos/POSIX/PurePOSIXPath.swift
+++ b/Sources/Pathos/POSIX/PurePOSIXPath.swift
@@ -128,8 +128,12 @@ public struct PurePOSIXPath {
 }
 
 extension PurePOSIXPath: ExpressibleByStringLiteral {
-    public init(stringLiteral value: String) {
-        self.init(value)
+    public init(stringLiteral value: StaticString) {
+        self.init(
+            value.withUTF8Buffer {
+                String(decoding: $0, as: UTF8.self)
+            }
+        )
     }
 }
 

--- a/Sources/Pathos/Path.swift
+++ b/Sources/Pathos/Path.swift
@@ -326,8 +326,12 @@ public struct Path {
 }
 
 extension Path: ExpressibleByStringLiteral {
-    public init(stringLiteral value: String) {
-        self.init(value)
+    public init(stringLiteral value: StaticString) {
+        self.init(
+            value.withUTF8Buffer {
+                String(decoding: $0, as: UTF8.self)
+            }
+        )
     }
 }
 

--- a/Sources/Pathos/Windows/PureWindowsPath.swift
+++ b/Sources/Pathos/Windows/PureWindowsPath.swift
@@ -135,8 +135,12 @@ public struct PureWindowsPath {
 }
 
 extension PureWindowsPath: ExpressibleByStringLiteral {
-    public init(stringLiteral value: String) {
-        self.init(value)
+    public init(stringLiteral value: StaticString) {
+        self.init(
+            value.withUTF8Buffer {
+                String(decoding: $0, as: UTF8.self)
+            }
+        )
     }
 }
 


### PR DESCRIPTION
Two `Path.init...`s take a `String`. So it would be ambiguous in code
like `someArrayOfString.map(Path.init)`. So one of them has to go.